### PR TITLE
[Fix] Trigger 'mq' event on 'orientationchange' event

### DIFF
--- a/source/assets/js/helpers/events.js
+++ b/source/assets/js/helpers/events.js
@@ -24,7 +24,7 @@
 		};
 
 	$(window)
-		.on('resize.estatico', _.debounce(function(event) {
+		.on('resize.estatico orientationchange.estatico', _.debounce(function(event) {
 			$document.triggerHandler(events.resize, event);
 		}, interval.resize))
 		.on('scroll.estatico', _.debounce(function(event) {


### PR DESCRIPTION
On mobile devices (in this case iPhone6 – iOS 8.1.3) the `resize` event was not triggered by an orientation change, therefore the `currentBreakpoint` was not updated.
This PR proposes to trigger the `mq` event on `orientationchange`.
