### PR TITLE
[Feature] Log: create a console.log wrapper with context

### DIFF
--- a/source/assets/js/head.js
+++ b/source/assets/js/head.js
@@ -15,6 +15,26 @@
 
 		// Helper methods
 		helpers: {
+		 	// PhantomJS doesn't support bind yet
+			// This serves as a fill-in taken from es5.js
+			// https://github.com/inexorabletash/polyfill
+			bind: function (o) {
+				if (typeof this !== 'function') {
+					throw new TypeError('Bind must be called on a function');
+				}
+				var slice = [].slice,
+					args = slice.call(arguments, 1),
+					self = this,
+				bound = function() {
+					return self.apply(this instanceof NOP ? this : o, args.concat(slice.call(arguments)));
+				};
+
+				function NOP() {}
+				NOP.prototype = self.prototype;
+				bound.prototype = new NOP();
+
+				return bound;
+			},
 			// Deep extend (before $.extend is available)
 			extend: function extend(destination, source) {
 				for (var property in source) {
@@ -30,13 +50,13 @@
 				return destination;
 			},
 			// Creates a console.log wrapper with optional namespace/context
-			log: function log(context) {
+			log: function log(contextName) {
 				var _fn;
 
-				if (typeof context === 'string' && context.length > 0) {
-					_fn = Function.prototype.bind.call(console.log, console, context);
+				if (typeof contextName === 'string' && contextName.length > 0) {
+					_fn = estatico.helpers.bind.call(console.log, console, contextName);
 				} else {
-					_fn = Function.prototype.bind.call(console.log, console);
+					_fn = estatico.helpers.bind.call(console.log, console);
 				}
 
 				return _fn;

--- a/source/assets/js/head.js
+++ b/source/assets/js/head.js
@@ -28,6 +28,18 @@
 				}
 
 				return destination;
+			},
+			// Creates a console.log wrapper with optional namespace/context
+			log: function log(context) {
+				var _fn;
+
+				if (typeof context === 'string' && context.length > 0) {
+					_fn = Function.prototype.bind.call(console.log, console, context);
+				} else {
+					_fn = Function.prototype.bind.call(console.log, console);
+				}
+
+				return _fn;
 			}
 		}
 	};

--- a/source/demo/modules/slideshow/slideshow.js
+++ b/source/demo/modules/slideshow/slideshow.js
@@ -31,7 +31,8 @@
 				prev: 'Previous Slide',
 				next: 'Next Slide'
 			}
-		};
+		},
+		log = estatico.helpers.log(name);
 
 	/**
 	 * Create an instance of the module
@@ -91,22 +92,22 @@
 				this.add(slide);
 			}, this));
 		}, this)).fail(function(jqXHR) {
-			console.log('NOO!', jqXHR.status, jqXHR.statusText);
+			log('NOO!', jqXHR.status, jqXHR.statusText);
 		});
 
 		// Exemplary touch detection
 		if (Modernizr.touchevents) {
-			console.log('slideshow.js', 'Touch support detected');
+			log('Touch support detected');
 		}
 
 		// Exemplary debounced resize listener (uuid used to make sure it can be unbound per plugin instance)
 		$(document).on(estatico.events.resize + '.' + this.uuid, function(event, originalEvent) {
-			console.log('slideshow.js', originalEvent);
+			log(originalEvent);
 		});
 
 		// Exemplary debounced scroll listener (uuid used to make sure it can be unbound per plugin instance)
 		$(document).on(estatico.events.scroll + '.' + this.uuid, function(event, originalEvent) {
-			console.log('slideshow.js', originalEvent);
+			log(originalEvent);
 		});
 
 		this.resize();
@@ -183,9 +184,9 @@
 	 */
 	Module.prototype.resize = function() {
 		if (parseInt(estatico.mq.currentBreakpoint.value) > parseInt(estatico.mq.breakpoints.small)) {
-			console.log('slideshow.js', 'Viewport: Above small breakpoint');
+			log('Viewport: Above small breakpoint');
 		} else {
-			console.log('slideshow.js', 'Viewport: Below small breakpoint');
+			log('Viewport: Below small breakpoint');
 		}
 	};
 

--- a/source/modules/.scaffold/module.js
+++ b/source/modules/.scaffold/module.js
@@ -24,7 +24,8 @@
 		},
 		data = {
 			// items: ["Item 1", "Item 2"]
-		};
+		},
+		log = estatico.helpers.log(name);
 
 	/**
 	 * Create an instance of the module
@@ -53,7 +54,7 @@
 	 * @public
 	 */
 	Module.prototype.init = function() {
-		// console.log('Module "{{name}}" initialized');
+		// log('Module initialized');
 	};
 
 	/**


### PR DESCRIPTION
We usually use a log wrapper such as [bows](https://github.com/latentflip/bows) to wrap and namespace our logs.
I implemented a simple console.log wrapper which keeps the linenumber and prepends all log messages with the current module name.

This allows two things:
- log statements can be left in production code if the wrapper is replaced with a `noop` function in production environment or has a mechanism to disable logs with localStorage. (e.g. [andlog](https://github.com/HenrikJoreteg/andlog))
- the global log wrapper can be replaced with a **wrapper of choice** (bows in our case)
  
  ``` javascript
  log: window.bows
  ```
