### PR TITLE
[Feature] mq.query: Add js mediaquery

### DIFF
--- a/docs/Coding_Guidelines.md
+++ b/docs/Coding_Guidelines.md
@@ -117,7 +117,7 @@ if (estatico.mq.currentBreakpoint.name === 'large') {
 }
 
 // Check the current viewport against a specific breakpoint:
-if (parseInt(estatico.mq.currentBreakpoint.value) > parseInt(estatico.mq.breakpoints.small)) {
+if (estatico.mq.query({ from: 'small' })) {
 	this.destroySmall();
 	this.initLarge();
 }

--- a/source/assets/js/helpers/mediaqueries.js
+++ b/source/assets/js/helpers/mediaqueries.js
@@ -68,17 +68,14 @@
 		return value;
 	}
 
-	function mediaQuery(options) {
+	function query(options) {
 		var breakpointFrom, breakpointTo,
 			breakpointCurrent = parseInt(estatico.mq.currentBreakpoint.value, 10);
 
 		if (typeof options !== 'object') {
-
 			// No or wrong arguments passed
 			throw 'Illegal argument of type "' + typeof options + '", expected "object"';
-
 		} else if (typeof options.to !== 'undefined' && typeof options.from !== 'undefined') {
-
 			breakpointFrom = getBreakpointValue(options.from);
 			breakpointTo = getBreakpointValue(options.to);
 
@@ -90,25 +87,18 @@
 			// The breakpoint needs to smaller than the "to" (exclusive)
 			// but larger or the same as "from" (inclusive)
 			return breakpointFrom <= breakpointCurrent && breakpointCurrent < breakpointTo;
-
 		} else if (typeof options.to !== 'undefined') {
-
 			breakpointTo = getBreakpointValue(options.to);
 
 			// Breakpoint needs to smaller than the "to" (exclusive)
 			return breakpointCurrent < breakpointTo;
-
 		} else if (typeof options.from !== 'undefined') {
-
 			breakpointFrom = getBreakpointValue(options.from);
 
 			// Breakpoint needs larger or the same as "from" (inclusive)
 			return breakpointCurrent >= breakpointFrom;
-
 		} else {
-
 			throw 'No values for "to" or "from" received';
-
 		}
 	}
 
@@ -116,7 +106,7 @@
 	$.extend(true, estatico, {
 		events: events,
 		mq: {
-			query: mediaQuery,
+			query: query,
 			breakpoints: breakpoints,
 			currentBreakpoint: currentBreakpoint
 		}

--- a/source/assets/js/helpers/mediaqueries.js
+++ b/source/assets/js/helpers/mediaqueries.js
@@ -17,9 +17,14 @@
  * }
  *
  * // Check the current viewport against a specific breakpoint:
- * if (parseInt(estatico.mq.currentBreakpoint.value) > parseInt(estatico.mq.breakpoints.small)) {
+ * if (estatico.mq.query({ from: 'small' }) {
  * 	this.destroySmall();
  * 	this.initLarge();
+ * }
+ * // or
+ * if (estatico.mq.query({ from: 'small', to: 'medium' }) {
+ * 	this.destroySmall();
+ * 	this.initMedium();
  * }
  */
 
@@ -52,10 +57,66 @@
 		}
 	});
 
+	function getBreakpointValue(breakpoint) {
+		var value = 0;
+
+		if (typeof breakpoints[breakpoint] !== 'undefined') {
+			value = parseInt(breakpoints[breakpoint], 10);
+		} else {
+			throw 'Breakpoint not found: "' + breakpoint + '"';
+		}
+		return value;
+	}
+
+	function mediaQuery(options) {
+		var breakpointFrom, breakpointTo,
+			breakpointCurrent = parseInt(estatico.mq.currentBreakpoint.value, 10);
+
+		if (typeof options !== 'object') {
+
+			// No or wrong arguments passed
+			throw 'Illegal argument of type "' + typeof options + '", expected "object"';
+
+		} else if (typeof options.to !== 'undefined' && typeof options.from !== 'undefined') {
+
+			breakpointFrom = getBreakpointValue(options.from);
+			breakpointTo = getBreakpointValue(options.to);
+
+			// "from" cannot be larger than "to"
+			if (breakpointFrom > breakpointTo) {
+				throw 'Breakpoint ' + breakpointFrom + ' is larger than ' + breakpointTo +  '';
+			}
+
+			// The breakpoint needs to smaller than the "to" (exclusive)
+			// but larger or the same as "from" (inclusive)
+			return breakpointFrom <= breakpointCurrent && breakpointCurrent < breakpointTo;
+
+		} else if (typeof options.to !== 'undefined') {
+
+			breakpointTo = getBreakpointValue(options.to);
+
+			// Breakpoint needs to smaller than the "to" (exclusive)
+			return breakpointCurrent < breakpointTo;
+
+		} else if (typeof options.from !== 'undefined') {
+
+			breakpointFrom = getBreakpointValue(options.from);
+
+			// Breakpoint needs larger or the same as "from" (inclusive)
+			return breakpointCurrent >= breakpointFrom;
+
+		} else {
+
+			throw 'No values for "to" or "from" received';
+
+		}
+	}
+
 	// Save to global namespace
 	$.extend(true, estatico, {
 		events: events,
 		mq: {
+			query: mediaQuery,
 			breakpoints: breakpoints,
 			currentBreakpoint: currentBreakpoint
 		}

--- a/source/assets/js/helpers/mediaqueries.js
+++ b/source/assets/js/helpers/mediaqueries.js
@@ -17,12 +17,12 @@
  * }
  *
  * // Check the current viewport against a specific breakpoint:
- * if (estatico.mq.query({ from: 'small' }) {
+ * if (estatico.mq.query({ from: 'small' })) {
  * 	this.destroySmall();
  * 	this.initLarge();
  * }
  * // or
- * if (estatico.mq.query({ from: 'small', to: 'medium' }) {
+ * if (estatico.mq.query({ from: 'small', to: 'medium' })) {
  * 	this.destroySmall();
  * 	this.initMedium();
  * }

--- a/source/demo/modules/slideshow/slideshow.js
+++ b/source/demo/modules/slideshow/slideshow.js
@@ -182,7 +182,7 @@
 	 * @public
 	 */
 	Module.prototype.resize = function() {
-		if (parseInt(estatico.mq.currentBreakpoint.value) > parseInt(estatico.mq.breakpoints.small)) {
+		if (estatico.mq.query({ from: 'small' })) {
 			console.log('slideshow.js', 'Viewport: Above small breakpoint');
 		} else {
 			console.log('slideshow.js', 'Viewport: Below small breakpoint');


### PR DESCRIPTION
Allows for js-based mediaqueries as described in #4 :

``` js
estatico.mq.query({ to: 'small' }); // false
estatico.mq.query({ from: 'small' }); // true
estatico.mq.query({ from: 'small', to: 'large' }); // true

if (estatico.mq.query({ from: 'small' })) {
    // ...
}
```

I haven't added any tests or jsdoc. Thoughts?
