### PR TITLE
[Feature] Gulp: Validate node.js version before running

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,18 @@
 'use strict';
 
+var validatenv = require('validate-node-version')(),
+	errors = require('./helpers/errors.js'),
+	util = require('gulp-util');
+
+// Check Node Version
+// To skip this check use the flag: `gulp --ignoreNodeVersion`
+if (!validatenv.satisfies && !util.env.ignoreNodeVersion) {
+	errors({
+		plugin: 'gulpfile.js',
+		message: validatenv.message + '. To skip this check use the following flag: `gulp --ignoreNodeVersion`'
+	});
+}
+
 // Load tasks
 require('require-dir')('./gulp', {
 	recurse: true

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "should": "11.1.0",
     "style-loader": "0.13.0",
     "through2": "2.0.1",
+    "validate-node-version": "1.1.1",
     "vinyl-buffer": "1.0.0",
     "vinyl-paths": "2.1.0",
     "webpack": "1.13.1"


### PR DESCRIPTION
This change adds a node.js version check before running any gulp tasks. The version check is based on the information in the package.json: 

```json
  "engines": {
    "node": "6.7.0"
  }
```