### PR TITLE
FontLoader: Do not insert result on 404

### DIFF
--- a/source/assets/js/helpers/fontloader.js
+++ b/source/assets/js/helpers/fontloader.js
@@ -2,13 +2,13 @@ import Helper from './helper';
 
 class FontLoader extends Helper {
 
-	constructor() {
+	constructor(href = '/assets/css/fonts.css?v1') {
 		super();
 		this.logger = this.log(FontLoader.name);
 
 		// once cached, the css file is stored on the client forever unless
 		// the URL below is changed. Any change will invalidate the cache
-		this.cssHref = '/assets/css/fonts.css?v1';
+		this.cssHref = href;
 
 		if (this._fileIsCached()) {
 			this.logger('just use the cached version');

--- a/source/assets/js/helpers/fontloader.js
+++ b/source/assets/js/helpers/fontloader.js
@@ -38,7 +38,7 @@ class FontLoader extends Helper {
 
 		// cater for IE8 which does not support addEventListener or attachEvent on XMLHttpRequest
 		xhr.onreadystatechange = () => {
-			if (xhr.readyState === 4) {
+			if (xhr.readyState === 4 && xhr.status === 200) {
 
 				// once we have the content, quickly inject the css rules
 				this._injectRawStyle(xhr.responseText);

--- a/source/preview/assets/css/main.scss
+++ b/source/preview/assets/css/main.scss
@@ -26,6 +26,7 @@ $sg_colorLightGray: #eaeaea;
 $sg_colorGray: #999;
 $sg_colorBlack: #000;
 $sg_colorUnicGreen: #a4c400;
+$sg_colorWarning: #c30;
 
 // Transitions
 $sg_defaultTransitionProperty: all;
@@ -98,6 +99,12 @@ $sg_defaultTransition: $sg_defaultTransitionProperty $sg_defaultTransitionDurati
 	.sg_h2 {
 		font-size: pxToEm(25px);
 	}
+}
+
+.sg_warning {
+	border: 1px solid $sg_colorWarning;
+	color: $sg_colorWarning;
+	padding: 1em;
 }
 
 

--- a/source/preview/styleguide/webfonts.hbs
+++ b/source/preview/styleguide/webfonts.hbs
@@ -7,6 +7,10 @@ In case of different sizes for each weight, they can be defined in separate obje
 
 {{#extend "preview/layouts/layout"}}
 	{{#content "content"}}
+		<section class="sg_inner_wrapper sg_warning">
+			<strong>Warning:</strong> By default, the font loader assumes to find a <code>/assets/css/fonts.css</code> file. This can be configured as a parameter of the <code>FontLoader</code> instance in <code>head.js</code>. The result is that this currently fails on our GitHub pages, e.g., where the whole build is in a subdirectory. Subsequently, the request to the CSS file will result in a 404 and Roboto will not be loaded.
+		</section>
+
 		{{#each fonts}}
 			<section class="sg_inner_wrapper">
 				<h2 class="sg_h2">family: {{family}}</h2>


### PR DESCRIPTION
We currently have the nice effect on github.io that our script inserts a 404 HTML page into a `<style>` element, screwing up our own styles along the way:

![image](https://cloud.githubusercontent.com/assets/654171/19930791/4e4e13ee-a10a-11e6-842a-3234a2632d95.png)

![image](https://cloud.githubusercontent.com/assets/654171/19930803/59c120fe-a10a-11e6-8463-a4e69c36e7cc.png)