### PR TITLE
Gulp scaffold: Fix issues with JS class name by pascal-casing it

### DIFF
--- a/gulp/scaffold/default.js
+++ b/gulp/scaffold/default.js
@@ -91,7 +91,7 @@ var taskName = 'scaffold',
 			})
 			.then(function(response) {
 				scaffoldConfig.name = response.sanitized;
-				scaffoldConfig.className = response.original;
+				scaffoldConfig.className = response.className;
 
 				if (hasAssets) {
 					return helpers.scaffold.getAssetsToCreate();

--- a/gulp/scaffold/rename.js
+++ b/gulp/scaffold/rename.js
@@ -51,7 +51,7 @@ var taskName = 'scaffold:rename',
 			})
 			.then(function(response) {
 				scaffoldConfig.name = response.sanitized;
-				scaffoldConfig.className = response.original;
+				scaffoldConfig.className = response.className;
 
 				scaffoldConfig.replaceContent = function(content, config) {
 					return content.replace(new RegExp(config.previousClassName, 'g'), config.className).replace(new RegExp(config.previousName, 'g'), config.name);

--- a/helpers/scaffold.js
+++ b/helpers/scaffold.js
@@ -106,6 +106,16 @@ function getSanitizedName(name, allowUnderscores) {
 	return (!allowUnderscores) ? name.replace(/_/g, '') : name;
 }
 
+/**
+ * Get pascal-cased name for JS class
+ * Example: "Hello World 2" returns "HelloWorld2"
+ * @param {String} name
+ * @return {String}
+ */
+function getClassName(name) {
+	return changeCase.pascal(name, null, true);
+}
+
 module.exports = {
 	/**
 	 * Get type
@@ -237,7 +247,8 @@ module.exports = {
 
 					resolve({
 						original: answers.name,
-						sanitized: name
+						sanitized: name,
+						className: getClassName(answers.name)
 					});
 				});
 			} else if (env && env !== true) {
@@ -250,7 +261,8 @@ module.exports = {
 				} else {
 					resolve({
 						original: env,
-						sanitized: name
+						sanitized: name,
+						className: getClassName(env)
 					});
 				}
 			} else {


### PR DESCRIPTION
Before, choosing "Foo Bar" as module name when running `gulp scaffold` did result in `import Foo Bar from '../../../modules/foobar/foobar';` in `estaticoapp.js`.

Thanks to @tschuems for pointing this out! Do you have additional input or should this resolve the issue you discovered?