### PR TITLE
Gulp: Use separate handlebars environment for html task

### DIFF
--- a/helpers/handlebars.js
+++ b/helpers/handlebars.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Handlebars
-var handlebars = require('handlebars'),
+var handlebars = require('handlebars').create(),
 	layouts = require('handlebars-layouts'),
 	helpers = require('handlebars-helpers'),
 	errors = require('./errors'),


### PR DESCRIPTION
Tasks and plugins using `var handlebars = require('handlebars')` will all get the same handlebars environment, allowing them to overwrite each other's helpers, e.g.

Using `.create()` will give us a separate environment for our own html tasks. This will fix an issue where the `handlebars-layouts` module bundled with `gulp.spritesmith` did overwrite our own layout helpers.