### PR TITLE
Module preview: Show rendered html and data model, move logic from gulp to data layer

### DIFF
--- a/gulp/css/colors.js
+++ b/gulp/css/colors.js
@@ -31,10 +31,11 @@ gulp.task(taskName, function() {
 	return gulp.src(taskConfig.src)
 		.pipe(plumber())
 		.pipe(handlebars({
-			handlebars: helpers.handlebars,
+			handlebars: helpers.handlebars.Handlebars.create(),
 			data: {
 				colors: colors
 			},
+			helpers: helpers.handlebars.helpers,
 			bustCache: true
 		}).on('error', helpers.errors))
 		.pipe(gulp.dest(taskConfig.dest));

--- a/gulp/document.js
+++ b/gulp/document.js
@@ -32,10 +32,7 @@ gulp.task(taskName, function() {
 		.pipe(concat('Tasks.md'))
 		.pipe(plumber())
 		.pipe(jsdocToMarkdown({
-			template: template,
-			helper: [
-				'./helpers/handlebars.js'
-			]
+			template: template
 		}).on('error', helpers.errors))
 		.pipe(gulp.dest(taskConfig.dest));
 });

--- a/gulp/html/default.js
+++ b/gulp/html/default.js
@@ -142,7 +142,7 @@ var taskName = 'html',
 			}))
 			.pipe(plumber())
 			.pipe(handlebars({
-				handlebars: helpers.handlebars,
+				handlebars: helpers.handlebars.Handlebars,
 				partials: config.partials,
 				parsePartialName: function(options, file) {
 					var filePath = file.path;

--- a/gulp/html/default.js
+++ b/gulp/html/default.js
@@ -64,20 +64,7 @@ var taskName = 'html',
 			handlebars = require('gulp-hb'),
 			through = require('through2');
 
-		var compileTemplate = function(template, data) {
-				try {
-					return helpers.handlebars.compile(template)(data);
-				} catch (err) {
-					helpers.errors({
-						task: taskName,
-						message: err.message
-					});
-
-					return '';
-				}
-			},
-
-			modulePreviewTemplate;
+		var modulePreviewTemplate;
 
 		gulp.src(config.src, {
 				base: './source'
@@ -140,35 +127,11 @@ var taskName = 'html',
 
 							return {};
 						}
-					})(),
+					})();
 
-					moduleTemplate,
-					mergedData;
-
-				// Precompile module demo and variants
+				// Replace module file content with preview template
 				if (file.path.indexOf(path.sep + 'modules' + path.sep) !== -1) {
-					moduleTemplate = file.contents.toString();
 					modulePreviewTemplate = modulePreviewTemplate || fs.readFileSync(config.srcModulePreview, 'utf8');
-
-					data.demo = compileTemplate(moduleTemplate, data);
-
-					// Compile variants
-					if (data.variants) {
-						data.variants = data.variants.map(function(variant) {
-							variant.demo = compileTemplate(moduleTemplate, variant);
-
-							return variant;
-						});
-
-						mergedData = _.extend({}, _.omit(data, ['project', 'env', 'meta', 'variants']), {
-								meta: {
-									title: 'Default',
-									desc: 'Default implementation.'
-								}
-							}
-						);
-						data.variants.unshift(mergedData);
-					}
 
 					// Replace file content with preview template
 					file.contents = new Buffer(modulePreviewTemplate);

--- a/gulp/media/pngsprite.js
+++ b/gulp/media/pngsprite.js
@@ -78,7 +78,7 @@ gulp.task(taskName, function(cb) {
 			gulp.src(taskConfig.srcStyles)
 				.pipe(plumber())
 				.pipe(handlebars({
-					handlebars: helpers.handlebars,
+					handlebars: helpers.handlebars.Handlebars.create(),
 					data: {
 						images: images
 					},

--- a/helpers/handlebars.js
+++ b/helpers/handlebars.js
@@ -1,42 +1,38 @@
 'use strict';
 
 // Handlebars
-var handlebars = require('handlebars').create(),
-	layouts = require('handlebars-layouts'),
-	helpers = require('handlebars-helpers'),
+var Handlebars = require('handlebars'),
+	handlebarsLayouts = require('handlebars-layouts'),
+	assembleHelpers = require('handlebars-helpers'),
 	errors = require('./errors'),
-	_ = require('lodash');
+	_ = require('lodash'),
+	helpers = {};
 
 // Make handlebars layout helpers available
-handlebars.registerHelper(layouts(handlebars));
+_.merge(helpers, handlebarsLayouts(Handlebars));
 
 // Make specific assemble helpers available
 // See http://assemble.io/helpers/ for a documentation
-//
 // Example: Use the comparisons provided by the handlebars-helpers package
-helpers.comparison({
-	handlebars: handlebars
-});
+helpers.comparison = assembleHelpers.comparison();
 
-// WARNING: For some helpers, grunt has to be installed (npm install grunt --save && npm shrinkwrap)
-// This might be fixed at some point: https://github.com/assemble/handlebars-helpers/pull/157
 
 // Custom Handlebars helpers
 
 // Capitalize string
-handlebars.registerHelper('capitalize', function(value) {
-	return new handlebars.SafeString(
+helpers.capitalize = function(value) {
+	return new Handlebars.SafeString(
 		value.charAt(0).toUpperCase() + value.substr(1)
 	);
-});
+};
 
 // Output raw block (use: {{{{raw}}}} blabla {{title}} bla{{{{/raw}}}})
-handlebars.registerHelper('raw', function(options) {
+helpers.raw = function(options) {
 	return options.fn();
-});
+};
 
 // Repeat something X times
-handlebars.registerHelper('times', function(n, block) {
+helpers.times = function(n, block) {
 	var output = '';
 
 	for (var i = 0; i < n; i++) {
@@ -44,14 +40,14 @@ handlebars.registerHelper('times', function(n, block) {
 	}
 
 	return output;
-});
+};
 
 // Include partial with dynamic name
 // Based on http://stackoverflow.com/a/21411521
 // @param {String} name - Partial path, can contain placeholder as "{{key}}"
 // @param {Object} partialData - Data to pass to the partial
 // @param {Object} options.replacementContext - Context to use for the placeholder replacement
-handlebars.registerHelper('dynamicPartial', function(name, partialData, options) {
+helpers.dynamicPartial = function(name, partialData, options) {
 	if (name === undefined) {
 		errors({
 			task: 'helpers/handlebars.js',
@@ -75,7 +71,7 @@ handlebars.registerHelper('dynamicPartial', function(name, partialData, options)
 		}
 	});
 
-	template = handlebars.partials[name];
+	template = Handlebars.partials[name];
 
 	if (template === undefined) {
 		errors({
@@ -87,12 +83,18 @@ handlebars.registerHelper('dynamicPartial', function(name, partialData, options)
 	}
 
 	if (typeof template !== 'function') {
-		template = handlebars.compile(template);
+		template = Handlebars.compile(template);
 	}
 
 	output = template(partialData).replace(/^\s+/, '');
 
-	return new handlebars.SafeString(output);
-});
+	return new Handlebars.SafeString(output);
+};
 
-module.exports = handlebars;
+// Register helpers
+Handlebars.registerHelper(helpers);
+
+module.exports = {
+	Handlebars: Handlebars,
+	helpers: helpers
+};

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "highlight.js": "9.7.0",
     "imports-loader": "0.6.5",
     "inquirer": "1.2.1",
+    "js-beautify": "1.6.4",
     "jshint-stylish": "2.2.1",
     "lazypipe": "1.0.1",
     "lodash": "4.16.4",

--- a/source/data/default.data.js
+++ b/source/data/default.data.js
@@ -6,11 +6,13 @@ var util = require('gulp-util'),
 			project: 'Estático'
 		},
 		env: util.env,
-		svgSprites: JSON.stringify([
+		props: {
+			svgSprites: JSON.stringify([
 
-			// Disabled since there are no icons by default
-			// '/assets/media/svg/base.svg'
-		])
+				// Disabled since there are no icons by default
+				// '/assets/media/svg/base.svg'
+			])
+		}
 	};
 
 module.exports = data;

--- a/source/data/default.data.js
+++ b/source/data/default.data.js
@@ -2,7 +2,9 @@
 
 var util = require('gulp-util'),
 	data = {
-		project: 'Estático',
+		meta: {
+			project: 'Estático'
+		},
 		env: util.env,
 		svgSprites: JSON.stringify([
 

--- a/source/demo/modules/imageversions/imageversions.data.js
+++ b/source/demo/modules/imageversions/imageversions.data.js
@@ -9,7 +9,7 @@ var _ = require('lodash'),
 	moduleData = {},
 	template = dataHelper.getFileContent('imageversions.hbs'),
 	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
-	data = _.merge(defaultData, {
+	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Image versions',
 			demo: compiledTemplate,
@@ -21,8 +21,7 @@ var _ = require('lodash'),
 				// data: dataHelper.getFormattedJson(moduleData)
 			},
 			documentation: dataHelper.getDocumentation('imageversions.md')
-		},
-		module: moduleData
+		}
 	});
 
 module.exports = data;

--- a/source/demo/modules/imageversions/imageversions.data.js
+++ b/source/demo/modules/imageversions/imageversions.data.js
@@ -2,14 +2,27 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
+	dataHelper = requireNew('../../../../helpers/data.js'),
+	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
+
+	moduleData = {},
+	template = dataHelper.getFileContent('imageversions.hbs'),
+	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
 	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Image versions',
-			code: dataHelper.getTemplateCode('imageversions.hbs'),
+			demo: compiledTemplate,
+			code: {
+
+				// handlebars: dataHelper.getFormattedHandlebars(template),
+				html: dataHelper.getFormattedHtml(compiledTemplate)
+
+				// data: dataHelper.getFormattedJson(moduleData)
+			},
 			documentation: dataHelper.getDocumentation('imageversions.md')
-		}
+		},
+		module: moduleData
 	});
 
 module.exports = data;

--- a/source/demo/modules/imageversions/imageversions.data.js
+++ b/source/demo/modules/imageversions/imageversions.data.js
@@ -6,22 +6,39 @@ var _ = require('lodash'),
 	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 
-	moduleData = {},
 	template = dataHelper.getFileContent('imageversions.hbs'),
-	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
-	data = _.merge(defaultData, moduleData, {
+	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Image versions',
-			demo: compiledTemplate,
-			code: {
-
-				// handlebars: dataHelper.getFormattedHandlebars(template),
-				html: dataHelper.getFormattedHtml(compiledTemplate)
-
-				// data: dataHelper.getFormattedJson(moduleData)
-			},
 			documentation: dataHelper.getDocumentation('imageversions.md')
+		},
+		props: {}
+	}),
+	variants = [
+		{
+			meta: {
+				title: 'Default',
+				desc: 'Default implementation'
+			}
 		}
+	].map(function(variant) {
+		var variantProps = _.merge({}, data, variant).props,
+			compiledVariant = handlebarsHelper.Handlebars.compile(template)(variantProps),
+			variantData = _.merge({}, data, variant, {
+				meta: {
+					demo: compiledVariant
+
+					// code: {
+					// 	handlebars: dataHelper.getFormattedHandlebars(template),
+					// 	html: dataHelper.getFormattedHtml(compiledVariant),
+					// 	data: dataHelper.getFormattedJson(variantProps)
+					// }
+				}
+			});
+
+		return variantData;
 	});
+
+data.variants = variants;
 
 module.exports = data;

--- a/source/demo/modules/imageversions/imageversions.data.js
+++ b/source/demo/modules/imageversions/imageversions.data.js
@@ -8,7 +8,7 @@ var _ = require('lodash'),
 
 	moduleData = {},
 	template = dataHelper.getFileContent('imageversions.hbs'),
-	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
 	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Image versions',

--- a/source/demo/modules/media/media.data.js
+++ b/source/demo/modules/media/media.data.js
@@ -2,14 +2,27 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
+	dataHelper = requireNew('../../../../helpers/data.js'),
+	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
+
+	moduleData = {},
+	template = dataHelper.getFileContent('media.hbs'),
+	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
 	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Media demo',
 			jira: 'JIRA-3',
-			code: dataHelper.getTemplateCode('media.hbs')
-		}
+			demo: compiledTemplate,
+			code: {
+
+				// handlebars: dataHelper.getFormattedHandlebars(template)
+				html: dataHelper.getFormattedHtml(compiledTemplate)
+
+				// data: dataHelper.getFormattedJson(moduleData)
+			}
+		},
+		module: moduleData
 	});
 
 module.exports = data;

--- a/source/demo/modules/media/media.data.js
+++ b/source/demo/modules/media/media.data.js
@@ -8,7 +8,7 @@ var _ = require('lodash'),
 
 	moduleData = {},
 	template = dataHelper.getFileContent('media.hbs'),
-	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
 	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Media demo',

--- a/source/demo/modules/media/media.data.js
+++ b/source/demo/modules/media/media.data.js
@@ -9,7 +9,7 @@ var _ = require('lodash'),
 	moduleData = {},
 	template = dataHelper.getFileContent('media.hbs'),
 	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
-	data = _.merge(defaultData, {
+	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Media demo',
 			jira: 'JIRA-3',
@@ -21,8 +21,7 @@ var _ = require('lodash'),
 
 				// data: dataHelper.getFormattedJson(moduleData)
 			}
-		},
-		module: moduleData
+		}
 	});
 
 module.exports = data;

--- a/source/demo/modules/media/media.data.js
+++ b/source/demo/modules/media/media.data.js
@@ -6,22 +6,39 @@ var _ = require('lodash'),
 	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 
-	moduleData = {},
 	template = dataHelper.getFileContent('media.hbs'),
-	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
-	data = _.merge(defaultData, moduleData, {
+	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Media demo',
-			jira: 'JIRA-3',
-			demo: compiledTemplate,
-			code: {
-
-				// handlebars: dataHelper.getFormattedHandlebars(template)
-				html: dataHelper.getFormattedHtml(compiledTemplate)
-
-				// data: dataHelper.getFormattedJson(moduleData)
+			jira: 'JIRA-3'
+		},
+		props: {}
+	}),
+	variants = [
+		{
+			meta: {
+				title: 'Default',
+				desc: 'Default implementation'
 			}
 		}
+	].map(function(variant) {
+		var variantProps = _.merge({}, data, variant).props,
+			compiledVariant = handlebarsHelper.Handlebars.compile(template)(variantProps),
+			variantData = _.merge({}, data, variant, {
+				meta: {
+					demo: compiledVariant
+
+					// code: {
+					// 	handlebars: dataHelper.getFormattedHandlebars(template),
+					// 	html: dataHelper.getFormattedHtml(compiledVariant),
+					// 	data: dataHelper.getFormattedJson(variantProps)
+					// }
+				}
+			});
+
+		return variantData;
 	});
+
+data.variants = variants;
 
 module.exports = data;

--- a/source/demo/modules/skiplinks/skiplinks.data.js
+++ b/source/demo/modules/skiplinks/skiplinks.data.js
@@ -18,7 +18,7 @@ var _ = require('lodash'),
 	},
 	template = dataHelper.getFileContent('skiplinks.hbs'),
 	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
-	data = _.merge(defaultData, {
+	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Skiplinks',
 			jira: 'JIRA-5',
@@ -28,8 +28,7 @@ var _ = require('lodash'),
 				html: dataHelper.getFormattedHtml(compiledTemplate),
 				data: dataHelper.getFormattedJson(moduleData)
 			}
-		},
-		module: moduleData
+		}
 	});
 
 module.exports = data;

--- a/source/demo/modules/skiplinks/skiplinks.data.js
+++ b/source/demo/modules/skiplinks/skiplinks.data.js
@@ -6,29 +6,47 @@ var _ = require('lodash'),
 	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 
-	moduleData = {
-		links: [
-			{
-				href: '#main',
-				accesskey: 1,
-				title: '[ALT + 1]',
-				label: 'Skip to content'
-			}
-		]
-	},
 	template = dataHelper.getFileContent('skiplinks.hbs'),
-	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
-	data = _.merge(defaultData, moduleData, {
+	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Skiplinks',
-			jira: 'JIRA-5',
-			demo: compiledTemplate,
-			code: {
-				handlebars: dataHelper.getFormattedHandlebars(template),
-				html: dataHelper.getFormattedHtml(compiledTemplate),
-				data: dataHelper.getFormattedJson(moduleData)
+			jira: 'JIRA-5'
+		},
+		props: {
+			links: [
+				{
+					href: '#main',
+					accesskey: 1,
+					title: '[ALT + 1]',
+					label: 'Skip to content'
+				}
+			]
+		}
+	}),
+	variants = [
+		{
+			meta: {
+				title: 'Default',
+				desc: 'Default implementation'
 			}
 		}
+	].map(function(variant) {
+		var variantProps = _.merge({}, data, variant).props,
+			compiledVariant = handlebarsHelper.Handlebars.compile(template)(variantProps),
+			variantData = _.merge({}, data, variant, {
+				meta: {
+					demo: compiledVariant,
+					code: {
+						handlebars: dataHelper.getFormattedHandlebars(template),
+						html: dataHelper.getFormattedHtml(compiledVariant),
+						data: dataHelper.getFormattedJson(variantProps)
+					}
+				}
+			});
+
+		return variantData;
 	});
+
+data.variants = variants;
 
 module.exports = data;

--- a/source/demo/modules/skiplinks/skiplinks.data.js
+++ b/source/demo/modules/skiplinks/skiplinks.data.js
@@ -17,7 +17,7 @@ var _ = require('lodash'),
 		]
 	},
 	template = dataHelper.getFileContent('skiplinks.hbs'),
-	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
 	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Skiplinks',

--- a/source/demo/modules/skiplinks/skiplinks.data.js
+++ b/source/demo/modules/skiplinks/skiplinks.data.js
@@ -2,14 +2,11 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
+	dataHelper = requireNew('../../../../helpers/data.js'),
+	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
-	data = _.merge(defaultData, {
-		meta: {
-			title: 'Demo: Skiplinks',
-			jira: 'JIRA-5',
-			code: dataHelper.getTemplateCode('skiplinks.hbs')
-		},
+
+	moduleData = {
 		links: [
 			{
 				href: '#main',
@@ -18,6 +15,21 @@ var _ = require('lodash'),
 				label: 'Skip to content'
 			}
 		]
+	},
+	template = dataHelper.getFileContent('skiplinks.hbs'),
+	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	data = _.merge(defaultData, {
+		meta: {
+			title: 'Demo: Skiplinks',
+			jira: 'JIRA-5',
+			demo: compiledTemplate,
+			code: {
+				handlebars: dataHelper.getFormattedHandlebars(template),
+				html: dataHelper.getFormattedHtml(compiledTemplate),
+				data: dataHelper.getFormattedJson(moduleData)
+			}
+		},
+		module: moduleData
 	});
 
 module.exports = data;

--- a/source/demo/modules/slideshow/slideshow.data.js
+++ b/source/demo/modules/slideshow/slideshow.data.js
@@ -6,32 +6,12 @@ var _ = require('lodash'),
 	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 
-	moduleData = {
-		slides: _.map(['600/201', '600/202', '600/203'], function(size, index) {
-			return {
-				src: 'http://www.fillmurray.com/' + size,
-				alt: 'Bill Murray ' + (index + 1)
-			};
-		}),
-
-		i18n: {
-			prev: 'Previous Slide',
-			next: 'Next Slide'
-		}
-	},
 	template = dataHelper.getFileContent('slideshow.hbs'),
-	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
-	data = _.merge(defaultData, moduleData, {
+	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Slideshow',
 			className: 'SlideShow',
 			jira: 'JIRA-4',
-			demo: compiledTemplate,
-			code: {
-				handlebars: dataHelper.getFormattedHandlebars(template),
-				html: dataHelper.getFormattedHtml(compiledTemplate),
-				data: dataHelper.getFormattedJson(moduleData)
-			},
 			documentation: dataHelper.getDocumentation('slideshow.md'),
 			testScripts: [
 				dataHelper.getTestScriptPath('slideshow.test.js')
@@ -42,7 +22,45 @@ var _ = require('lodash'),
 					data: dataHelper.getDataMock('slideshow.mock.js')
 				}
 			]
+		},
+		props: {
+			slides: _.map(['600/201', '600/202', '600/203'], function(size, index) {
+				return {
+					src: 'http://www.fillmurray.com/' + size,
+					alt: 'Bill Murray ' + (index + 1)
+				};
+			}),
+
+			i18n: {
+				prev: 'Previous Slide',
+				next: 'Next Slide'
+			}
 		}
+	}),
+	variants = [
+		{
+			meta: {
+				title: 'Default',
+				desc: 'Default implementation'
+			}
+		}
+	].map(function(variant) {
+		var variantProps = _.merge({}, data, variant).props,
+			compiledVariant = handlebarsHelper.Handlebars.compile(template)(variantProps),
+			variantData = _.merge({}, data, variant, {
+				meta: {
+					demo: compiledVariant,
+					code: {
+						handlebars: dataHelper.getFormattedHandlebars(template),
+						html: dataHelper.getFormattedHtml(compiledVariant),
+						data: dataHelper.getFormattedJson(variantProps)
+					}
+				}
+			});
+
+		return variantData;
 	});
+
+data.variants = variants;
 
 module.exports = data;

--- a/source/demo/modules/slideshow/slideshow.data.js
+++ b/source/demo/modules/slideshow/slideshow.data.js
@@ -21,7 +21,7 @@ var _ = require('lodash'),
 	},
 	template = dataHelper.getFileContent('slideshow.hbs'),
 	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
-	data = _.merge(defaultData, {
+	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Slideshow',
 			className: 'SlideShow',
@@ -42,8 +42,7 @@ var _ = require('lodash'),
 					data: dataHelper.getDataMock('slideshow.mock.js')
 				}
 			]
-		},
-		module: moduleData
+		}
 	});
 
 module.exports = data;

--- a/source/demo/modules/slideshow/slideshow.data.js
+++ b/source/demo/modules/slideshow/slideshow.data.js
@@ -2,25 +2,11 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
+	dataHelper = requireNew('../../../../helpers/data.js'),
+	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
-	data = _.merge(defaultData, {
-		meta: {
-			title: 'Demo: Slideshow',
-			className: 'SlideShow',
-			jira: 'JIRA-4',
-			code: dataHelper.getTemplateCode('slideshow.hbs'),
-			documentation: dataHelper.getDocumentation('slideshow.md'),
-			testScripts: [
-				dataHelper.getTestScriptPath('slideshow.test.js')
-			],
-			mocks: [
-				{
-					description: null,
-					data: dataHelper.getDataMock('slideshow.mock.js')
-				}
-			]
-		},
+
+	moduleData = {
 		slides: _.map(['600/201', '600/202', '600/203'], function(size, index) {
 			return {
 				src: 'http://www.fillmurray.com/' + size,
@@ -32,6 +18,32 @@ var _ = require('lodash'),
 			prev: 'Previous Slide',
 			next: 'Next Slide'
 		}
+	},
+	template = dataHelper.getFileContent('slideshow.hbs'),
+	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	data = _.merge(defaultData, {
+		meta: {
+			title: 'Demo: Slideshow',
+			className: 'SlideShow',
+			jira: 'JIRA-4',
+			demo: compiledTemplate,
+			code: {
+				handlebars: dataHelper.getFormattedHandlebars(template),
+				html: dataHelper.getFormattedHtml(compiledTemplate),
+				data: dataHelper.getFormattedJson(moduleData)
+			},
+			documentation: dataHelper.getDocumentation('slideshow.md'),
+			testScripts: [
+				dataHelper.getTestScriptPath('slideshow.test.js')
+			],
+			mocks: [
+				{
+					description: null,
+					data: dataHelper.getDataMock('slideshow.mock.js')
+				}
+			]
+		},
+		module: moduleData
 	});
 
 module.exports = data;

--- a/source/demo/modules/slideshow/slideshow.data.js
+++ b/source/demo/modules/slideshow/slideshow.data.js
@@ -20,7 +20,7 @@ var _ = require('lodash'),
 		}
 	},
 	template = dataHelper.getFileContent('slideshow.hbs'),
-	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
 	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Slideshow',

--- a/source/demo/modules/slideshow/slideshow.js
+++ b/source/demo/modules/slideshow/slideshow.js
@@ -101,9 +101,12 @@ class SlideShow extends EstaticoModule {
 	 * @public
 	 */
 	add(data) {
-		var slide = templates.slide(data);
+		var slide = templates.slide(data),
+			$slide = $(slide);
 
-		$(slide).appendTo(this.ui.$wrapper);
+		$slide.appendTo(this.ui.$wrapper);
+
+		this.ui.$slides = this.ui.$slides.add($slide);
 	}
 
 	/**

--- a/source/demo/modules/svgsprite/svgsprite.data.js
+++ b/source/demo/modules/svgsprite/svgsprite.data.js
@@ -34,7 +34,7 @@ var _ = require('lodash'),
 	},
 	template = dataHelper.getFileContent('svgsprite.hbs'),
 	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
-	data = _.merge(defaultData, {
+	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: SVG icons',
 			jira: 'ESTATICO-212',
@@ -44,8 +44,7 @@ var _ = require('lodash'),
 				html: dataHelper.getFormattedHtml(compiledTemplate)
 			},
 			documentation: dataHelper.getDocumentation('svgsprite.md')
-		},
-		module: moduleData
+		}
 	});
 
 module.exports = data;

--- a/source/demo/modules/svgsprite/svgsprite.data.js
+++ b/source/demo/modules/svgsprite/svgsprite.data.js
@@ -9,6 +9,7 @@ var _ = require('lodash'),
 	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 
+	template = dataHelper.getFileContent('svgsprite.hbs'),
 	sprites = _.mapValues(spriteTask.taskConfig.src, function(globs) {
 		var files = [];
 
@@ -25,26 +26,44 @@ var _ = require('lodash'),
 
 		return files;
 	}),
-
-	moduleData = {
-		svgSprites: JSON.stringify(JSON.parse(defaultData.svgSprites || '[]').concat([
-			'/assets/media/svg/demo.svg'
-		])),
-		preview: sprites
-	},
-	template = dataHelper.getFileContent('svgsprite.hbs'),
-	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
-	data = _.merge(defaultData, moduleData, {
+	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: SVG icons',
 			jira: 'ESTATICO-212',
-			demo: compiledTemplate,
-			code: {
-				handlebars: dataHelper.getFormattedHandlebars(template),
-				html: dataHelper.getFormattedHtml(compiledTemplate)
-			},
 			documentation: dataHelper.getDocumentation('svgsprite.md')
+		},
+		svgSprites: JSON.stringify(JSON.parse(defaultData.svgSprites || '[]').concat([
+			'/assets/media/svg/demo.svg'
+		])),
+		props: {
+			preview: sprites
 		}
+	}),
+	variants = [
+		{
+			meta: {
+				title: 'Default',
+				desc: 'Default implementation'
+			}
+		}
+	].map(function(variant) {
+		var variantProps = _.merge({}, data, variant).props,
+			compiledVariant = handlebarsHelper.Handlebars.compile(template)(variantProps),
+			variantData = _.merge({}, data, variant, {
+				meta: {
+					demo: compiledVariant
+
+					// code: {
+					// 	handlebars: dataHelper.getFormattedHandlebars(template),
+					// 	html: dataHelper.getFormattedHtml(compiledVariant),
+					// 	data: dataHelper.getFormattedJson(variantProps)
+					// }
+				}
+			});
+
+		return variantData;
 	});
+
+data.variants = variants;
 
 module.exports = data;

--- a/source/demo/modules/svgsprite/svgsprite.data.js
+++ b/source/demo/modules/svgsprite/svgsprite.data.js
@@ -5,8 +5,10 @@ var _ = require('lodash'),
 	glob = require('glob'),
 	path = require('path'),
 	spriteTask = require('../../../../gulp/media/svgsprite.js'),
-	dataHelper = require('../../../../helpers/data.js'),
+	dataHelper = requireNew('../../../../helpers/data.js'),
+	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
+
 	sprites = _.mapValues(spriteTask.taskConfig.src, function(globs) {
 		var files = [];
 
@@ -24,17 +26,26 @@ var _ = require('lodash'),
 		return files;
 	}),
 
-	data = _.merge(defaultData, {
-		meta: {
-			title: 'Demo: SVG icons',
-			jira: 'ESTATICO-212',
-			code: dataHelper.getTemplateCode('svgsprite.hbs'),
-			documentation: dataHelper.getDocumentation('svgsprite.md')
-		},
+	moduleData = {
 		svgSprites: JSON.stringify(JSON.parse(defaultData.svgSprites || '[]').concat([
 			'/assets/media/svg/demo.svg'
 		])),
 		preview: sprites
+	},
+	template = dataHelper.getFileContent('svgsprite.hbs'),
+	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	data = _.merge(defaultData, {
+		meta: {
+			title: 'Demo: SVG icons',
+			jira: 'ESTATICO-212',
+			demo: compiledTemplate,
+			code: {
+				handlebars: dataHelper.getFormattedHandlebars(template),
+				html: dataHelper.getFormattedHtml(compiledTemplate)
+			},
+			documentation: dataHelper.getDocumentation('svgsprite.md')
+		},
+		module: moduleData
 	});
 
 module.exports = data;

--- a/source/demo/modules/svgsprite/svgsprite.data.js
+++ b/source/demo/modules/svgsprite/svgsprite.data.js
@@ -32,10 +32,10 @@ var _ = require('lodash'),
 			jira: 'ESTATICO-212',
 			documentation: dataHelper.getDocumentation('svgsprite.md')
 		},
-		svgSprites: JSON.stringify(JSON.parse(defaultData.svgSprites || '[]').concat([
-			'/assets/media/svg/demo.svg'
-		])),
 		props: {
+			svgSprites: JSON.stringify(JSON.parse(defaultData.props.svgSprites || '[]').concat([
+				'/assets/media/svg/demo.svg'
+			])),
 			preview: sprites
 		}
 	}),

--- a/source/demo/modules/svgsprite/svgsprite.data.js
+++ b/source/demo/modules/svgsprite/svgsprite.data.js
@@ -33,7 +33,7 @@ var _ = require('lodash'),
 		preview: sprites
 	},
 	template = dataHelper.getFileContent('svgsprite.hbs'),
-	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
 	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: SVG icons',

--- a/source/demo/modules/teaser/teaser.data.js
+++ b/source/demo/modules/teaser/teaser.data.js
@@ -11,7 +11,7 @@ var _ = require('lodash'),
 		text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.'
 	},
 	template = dataHelper.getFileContent('teaser.hbs'),
-	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
 	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Teaser with module variants',
@@ -48,7 +48,7 @@ var _ = require('lodash'),
 			variant: 'var_inverted'
 		}
 	].map(function(variant) {
-		var compiledVariant = handlebarsHelper.compile(template)(variant),
+		var compiledVariant = handlebarsHelper.Handlebars.compile(template)(variant),
 			variantData = _.merge({}, data, variant, {
 				meta: {
 					demo: compiledVariant,

--- a/source/demo/modules/teaser/teaser.data.js
+++ b/source/demo/modules/teaser/teaser.data.js
@@ -2,33 +2,74 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
+	dataHelper = requireNew('../../../../helpers/data.js'),
+	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
+
+	moduleData = {
+		title: 'Teaser title',
+		text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.'
+	},
+	template = dataHelper.getFileContent('teaser.hbs'),
+	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
 	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Teaser with module variants',
-			code: dataHelper.getTemplateCode('teaser.hbs')
-		},
-		title: 'Teaser title',
-		text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-		variants: [
-			{
-				meta: {
-					title: 'No text',
-					desc: 'Used when there are no words.'
-				},
-				title: 'Teaser title'
+			demo: compiledTemplate
+
+			// code: {
+			// 	handlebars: dataHelper.getFormattedHandlebars(template),
+			// 	html: dataHelper.getFormattedHtml(compiledTemplate),
+			// 	data: dataHelper.getFormattedJson(moduleData)
+			// }
+		}
+	}),
+	variants = [
+		{
+			meta: {
+				title: 'Default',
+				desc: 'Default implemention.'
 			},
-			{
-				meta: {
-					title: 'Inverted',
-					desc: 'Used at night. Set `variant` to `var_inverted`.'
-				},
+			module: moduleData
+		},
+		{
+			meta: {
+				title: 'No text',
+				desc: 'Used when there are no words.'
+			},
+			module: {
+				title: 'Teaser title'
+			}
+		},
+		{
+			meta: {
+				title: 'Inverted',
+				desc: 'Used at night. Set `variant` to `var_inverted`.'
+			},
+			module: {
 				title: 'Teaser title',
 				text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
 				variant: 'var_inverted'
 			}
-		]
+		}
+	].map(function(variant) {
+		var compiledVariant = handlebarsHelper.compile(template)(variant.module),
+			variantData = _.merge({}, data, variant, {
+				meta: {
+					demo: compiledVariant,
+					code: {
+						handlebars: dataHelper.getFormattedHandlebars(template),
+						html: dataHelper.getFormattedHtml(compiledVariant),
+						data: dataHelper.getFormattedJson(variant.module)
+					}
+				}
+			});
+
+		// delete variantData.meta.code.handlebars;
+
+		return variantData;
 	});
+
+data.variants = variants;
 
 module.exports = data;

--- a/source/demo/modules/teaser/teaser.data.js
+++ b/source/demo/modules/teaser/teaser.data.js
@@ -6,29 +6,21 @@ var _ = require('lodash'),
 	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 
-	moduleData = {
-		title: 'Teaser title',
-		text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.'
-	},
 	template = dataHelper.getFileContent('teaser.hbs'),
-	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
-	data = _.merge(defaultData, moduleData, {
+	data = _.merge(defaultData, {
 		meta: {
-			title: 'Demo: Teaser with module variants',
-			demo: compiledTemplate
-
-			// code: {
-			// 	handlebars: dataHelper.getFormattedHandlebars(template),
-			// 	html: dataHelper.getFormattedHtml(compiledTemplate),
-			// 	data: dataHelper.getFormattedJson(moduleData)
-			// }
+			title: 'Demo: Teaser with module variants'
+		},
+		props: {
+			title: 'Teaser title',
+			text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.'
 		}
 	}),
 	variants = [
 		{
 			meta: {
 				title: 'Default',
-				desc: 'Default implemention.'
+				desc: 'Default implementation'
 			}
 		},
 		{
@@ -36,31 +28,35 @@ var _ = require('lodash'),
 				title: 'No text',
 				desc: 'Used when there are no words.'
 			},
-			title: 'Teaser title'
+			props: {
+				title: 'Teaser title',
+				text: null
+			}
 		},
 		{
 			meta: {
 				title: 'Inverted',
 				desc: 'Used at night. Set `variant` to `var_inverted`.'
 			},
-			title: 'Teaser title',
-			text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-			variant: 'var_inverted'
+			props: {
+				title: 'Teaser title',
+				text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+				variant: 'var_inverted'
+			}
 		}
 	].map(function(variant) {
-		var compiledVariant = handlebarsHelper.Handlebars.compile(template)(variant),
+		var variantProps = _.merge({}, data, variant).props,
+			compiledVariant = handlebarsHelper.Handlebars.compile(template)(variantProps),
 			variantData = _.merge({}, data, variant, {
 				meta: {
 					demo: compiledVariant,
 					code: {
 						handlebars: dataHelper.getFormattedHandlebars(template),
 						html: dataHelper.getFormattedHtml(compiledVariant),
-						data: dataHelper.getFormattedJson(variant)
+						data: dataHelper.getFormattedJson(variantProps)
 					}
 				}
 			});
-
-		// delete variantData.meta.code.handlebars;
 
 		return variantData;
 	});

--- a/source/demo/modules/teaser/teaser.data.js
+++ b/source/demo/modules/teaser/teaser.data.js
@@ -12,7 +12,7 @@ var _ = require('lodash'),
 	},
 	template = dataHelper.getFileContent('teaser.hbs'),
 	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
-	data = _.merge(defaultData, {
+	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Teaser with module variants',
 			demo: compiledTemplate
@@ -29,38 +29,33 @@ var _ = require('lodash'),
 			meta: {
 				title: 'Default',
 				desc: 'Default implemention.'
-			},
-			module: moduleData
+			}
 		},
 		{
 			meta: {
 				title: 'No text',
 				desc: 'Used when there are no words.'
 			},
-			module: {
-				title: 'Teaser title'
-			}
+			title: 'Teaser title'
 		},
 		{
 			meta: {
 				title: 'Inverted',
 				desc: 'Used at night. Set `variant` to `var_inverted`.'
 			},
-			module: {
-				title: 'Teaser title',
-				text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-				variant: 'var_inverted'
-			}
+			title: 'Teaser title',
+			text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+			variant: 'var_inverted'
 		}
 	].map(function(variant) {
-		var compiledVariant = handlebarsHelper.compile(template)(variant.module),
+		var compiledVariant = handlebarsHelper.compile(template)(variant),
 			variantData = _.merge({}, data, variant, {
 				meta: {
 					demo: compiledVariant,
 					code: {
 						handlebars: dataHelper.getFormattedHandlebars(template),
 						html: dataHelper.getFormattedHtml(compiledVariant),
-						data: dataHelper.getFormattedJson(variant.module)
+						data: dataHelper.getFormattedJson(variant)
 					}
 				}
 			});

--- a/source/demo/modules/teasers/teasers.data.js
+++ b/source/demo/modules/teasers/teasers.data.js
@@ -5,29 +5,47 @@ var _ = require('lodash'),
 	dataHelper = requireNew('../../../../helpers/data.js'),
 	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
-	teaserData = requireNew('../teaser/teaser.data.js'),
+	teaserData = requireNew('../teaser/teaser.data.js').props,
 
-	moduleData = {
-		teasers: _.map(['Teaser 1', 'Teaser 2', 'Teaser 3', 'Teaser 4'], function(value) {
-			return _.merge({}, teaserData, {
-				title: value
-			});
-		})
-	},
 	template = dataHelper.getFileContent('teasers.hbs'),
-	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
-	data = _.merge(defaultData, moduleData, {
+	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Teasers',
 			jira: 'JIRA-1',
-			feature: 'Feature X',
-			demo: compiledTemplate,
-			code: {
-				handlebars: dataHelper.getFormattedHandlebars(template),
-				html: dataHelper.getFormattedHtml(compiledTemplate),
-				data: dataHelper.getFormattedJson(moduleData)
+			feature: 'Feature X'
+		},
+		props: {
+			teasers: _.map(['Teaser 1', 'Teaser 2', 'Teaser 3', 'Teaser 4'], function(value) {
+				return _.merge({}, teaserData, {
+					title: value
+				});
+			})
+		}
+	}),
+	variants = [
+		{
+			meta: {
+				title: 'Default',
+				desc: 'Default implementation'
 			}
 		}
+	].map(function(variant) {
+		var variantProps = _.merge({}, data, variant).props,
+			compiledVariant = handlebarsHelper.Handlebars.compile(template)(variantProps),
+			variantData = _.merge({}, data, variant, {
+				meta: {
+					demo: compiledVariant,
+					code: {
+						handlebars: dataHelper.getFormattedHandlebars(template),
+						html: dataHelper.getFormattedHtml(compiledVariant),
+						data: dataHelper.getFormattedJson(variantProps)
+					}
+				}
+			});
+
+		return variantData;
 	});
+
+data.variants = variants;
 
 module.exports = data;

--- a/source/demo/modules/teasers/teasers.data.js
+++ b/source/demo/modules/teasers/teasers.data.js
@@ -15,7 +15,7 @@ var _ = require('lodash'),
 		})
 	},
 	template = dataHelper.getFileContent('teasers.hbs'),
-	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
 	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Teasers',

--- a/source/demo/modules/teasers/teasers.data.js
+++ b/source/demo/modules/teasers/teasers.data.js
@@ -2,21 +2,33 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
+	dataHelper = requireNew('../../../../helpers/data.js'),
+	handlebarsHelper = requireNew('../../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 	teaserData = requireNew('../teaser/teaser.data.js'),
+
+	moduleData = {
+		teasers: _.map(['Teaser 1', 'Teaser 2', 'Teaser 3', 'Teaser 4'], function(value) {
+			return _.merge({}, teaserData.module, {
+				title: value
+			});
+		})
+	},
+	template = dataHelper.getFileContent('teasers.hbs'),
+	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
 	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Teasers',
 			jira: 'JIRA-1',
 			feature: 'Feature X',
-			code: dataHelper.getTemplateCode('teasers.hbs')
+			demo: compiledTemplate,
+			code: {
+				handlebars: dataHelper.getFormattedHandlebars(template),
+				html: dataHelper.getFormattedHtml(compiledTemplate),
+				data: dataHelper.getFormattedJson(moduleData)
+			}
 		},
-		teasers: _.map(['Teaser 1', 'Teaser 2', 'Teaser 3', 'Teaser 4'], function(value) {
-			return _.merge({}, teaserData, {
-				title: value
-			});
-		})
+		module: moduleData
 	});
 
 module.exports = data;

--- a/source/demo/modules/teasers/teasers.data.js
+++ b/source/demo/modules/teasers/teasers.data.js
@@ -9,14 +9,14 @@ var _ = require('lodash'),
 
 	moduleData = {
 		teasers: _.map(['Teaser 1', 'Teaser 2', 'Teaser 3', 'Teaser 4'], function(value) {
-			return _.merge({}, teaserData.module, {
+			return _.merge({}, teaserData, {
 				title: value
 			});
 		})
 	},
 	template = dataHelper.getFileContent('teasers.hbs'),
 	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
-	data = _.merge(defaultData, {
+	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: 'Demo: Teasers',
 			jira: 'JIRA-1',
@@ -27,8 +27,7 @@ var _ = require('lodash'),
 				html: dataHelper.getFormattedHtml(compiledTemplate),
 				data: dataHelper.getFormattedJson(moduleData)
 			}
-		},
-		module: moduleData
+		}
 	});
 
 module.exports = data;

--- a/source/demo/pages/handlebars/handlebars.data.js
+++ b/source/demo/pages/handlebars/handlebars.data.js
@@ -7,22 +7,24 @@ var _ = require('lodash'),
 		meta: {
 			title: 'Demo: 04 Handlebars helpers'
 		},
-		title: 'Handlebars helpers',
-		text: 'This page demonstrates the use of a some handlebars helpers (see helpers/handlebars.js).',
-		warning: 'WARNING: Use them with caution, they currently won\'t work on the client-side when precompiling templates.',
-		partial: 'demo/modules/slideshow/slideshow',
-		partialPlaceholder: 'slideshow',
-		partials: [
-			{
-				placeholder: 'slideshow'
+		props: {
+			title: 'Handlebars helpers',
+			text: 'This page demonstrates the use of a some handlebars helpers (see helpers/handlebars.js).',
+			warning: 'WARNING: Use them with caution, they currently won\'t work on the client-side when precompiling templates.',
+			partial: 'demo/modules/slideshow/slideshow',
+			partialPlaceholder: 'slideshow',
+			partials: [
+				{
+					placeholder: 'slideshow'
+				}
+			],
+			testString: 'hello world',
+			subString: 'hello',
+			testString2: 'hello world',
+			modules: {
+				skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
+				slideshow: requireNew('../../modules/slideshow/slideshow.data.js').props
 			}
-		],
-		testString: 'hello world',
-		subString: 'hello',
-		testString2: 'hello world',
-		modules: {
-			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
-			slideshow: requireNew('../../modules/slideshow/slideshow.data.js').props
 		}
 	});
 

--- a/source/demo/pages/handlebars/handlebars.data.js
+++ b/source/demo/pages/handlebars/handlebars.data.js
@@ -21,8 +21,8 @@ var _ = require('lodash'),
 		subString: 'hello',
 		testString2: 'hello world',
 		modules: {
-			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js'),
-			slideshow: requireNew('../../modules/slideshow/slideshow.data.js')
+			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
+			slideshow: requireNew('../../modules/slideshow/slideshow.data.js').props
 		}
 	});
 

--- a/source/demo/pages/handlebars/handlebars.hbs
+++ b/source/demo/pages/handlebars/handlebars.hbs
@@ -4,42 +4,44 @@
 	{{/content}}
 
 	{{#content "content"}}
-		<h2>{{title}}</h2>
+		{{#with props}}
+			<h2>{{title}}</h2>
 
-		<p>{{text}}</p>
+			<p>{{text}}</p>
 
-		<p><strong>{{warning}}</strong></p>
+			<p><strong>{{warning}}</strong></p>
 
-		<hr>
+			<hr>
 
-		<h3>Dynamic partial ({{partial}})</h3>
+			<h3>Dynamic partial ({{partial}})</h3>
 
-		{{dynamicPartial partial modules.slideshow}}
+			{{dynamicPartial partial modules.slideshow}}
 
-		<h3>Dynamic partial with placeholder in name ("demo/modules/slideshow/{{{{raw}}}}{{partialPlaceholder}}{{{{/raw}}}}")</h3>
+			<h3>Dynamic partial with placeholder in name ("demo/modules/slideshow/{{{{raw}}}}{{partialPlaceholder}}{{{{/raw}}}}")</h3>
 
-		{{dynamicPartial "demo/modules/slideshow/{{partialPlaceholder}}" modules.slideshow replacementContext=this}}
+			{{dynamicPartial "demo/modules/slideshow/{{partialPlaceholder}}" modules.slideshow replacementContext=this}}
 
-		<h3>Dynamic partial inside each loop</h3>
+			<h3>Dynamic partial inside each loop</h3>
 
-		{{#each partials}}
-			{{dynamicPartial "demo/modules/slideshow/{{placeholder}}" ../modules.slideshow replacementContext=this}}
-		{{/each}}
+			{{#each partials}}
+				{{dynamicPartial "demo/modules/slideshow/{{placeholder}}" ../modules.slideshow replacementContext=this}}
+			{{/each}}
 
-		<h3>Comparisons: Check if string contains substring</h3>
+			<h3>Comparisons: Check if string contains substring</h3>
 
-		{{#contains testString subString}}
-			"{{testString}}" contains "{{subString}}"
-		{{else}}
-			"{{testString}}" does not contain "{{subString}}"
-		{{/contains}}
+			{{#contains testString subString}}
+				"{{testString}}" contains "{{subString}}"
+			{{else}}
+				"{{testString}}" does not contain "{{subString}}"
+			{{/contains}}
 
-		<h3>Comparisons: Check if string is equal to other string</h3>
+			<h3>Comparisons: Check if string is equal to other string</h3>
 
-		{{#is testString testString2}}
-			"{{testString}}" is equal to "{{testString2}}"
-		{{else}}
-			"{{testString}}" is not equal to "{{testString2}}"
-		{{/is}}
+			{{#is testString testString2}}
+				"{{testString}}" is equal to "{{testString2}}"
+			{{else}}
+				"{{testString}}" is not equal to "{{testString2}}"
+			{{/is}}
+		{{/with}}
 	{{/content}}
 {{/extend}}

--- a/source/demo/pages/page/page.data.js
+++ b/source/demo/pages/page/page.data.js
@@ -7,11 +7,13 @@ var _ = require('lodash'),
 		meta: {
 			title: 'Demo: 01 Page'
 		},
-		title: 'Page',
-		text: 'This page demonstrates the inclusion of a module.',
-		modules: {
-			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
-			teasers: requireNew('../../modules/teasers/teasers.data.js').props
+		props: {
+			title: 'Page',
+			text: 'This page demonstrates the inclusion of a module.',
+			modules: {
+				skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
+				teasers: requireNew('../../modules/teasers/teasers.data.js').props
+			}
 		}
 	});
 

--- a/source/demo/pages/page/page.data.js
+++ b/source/demo/pages/page/page.data.js
@@ -10,8 +10,8 @@ var _ = require('lodash'),
 		title: 'Page',
 		text: 'This page demonstrates the inclusion of a module.',
 		modules: {
-			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js'),
-			teasers: requireNew('../../modules/teasers/teasers.data.js')
+			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
+			teasers: requireNew('../../modules/teasers/teasers.data.js').props
 		}
 	});
 

--- a/source/demo/pages/page/page.hbs
+++ b/source/demo/pages/page/page.hbs
@@ -1,15 +1,19 @@
 {{#extend "layouts/layout"}}
 	{{#content "header"}}
-		{{> "demo/modules/skiplinks/skiplinks" modules.skiplinks}}
+		{{#with props}}
+			{{> "demo/modules/skiplinks/skiplinks" modules.skiplinks}}
+		{{/with}}
 	{{/content}}
 
 	{{#content "content"}}
-		<h2>{{title}}</h2>
+		{{#with props}}
+			<h2>{{title}}</h2>
 
-		<p>{{text}}</p>
+			<p>{{text}}</p>
 
-		<hr>
+			<hr>
 
-		{{> "demo/modules/teasers/teasers" modules.teasers}}
+			{{> "demo/modules/teasers/teasers" modules.teasers}}
+		{{/with}}
 	{{/content}}
 {{/extend}}

--- a/source/demo/pages/page_2/page_2.data.js
+++ b/source/demo/pages/page_2/page_2.data.js
@@ -7,17 +7,19 @@ var _ = require('lodash'),
 		meta: {
 			title: 'Demo: 02 Page (custom teasers)'
 		},
-		title: 'Page (custom teasers)',
-		text: 'This page demonstrates the inclusion of a module with custom data.',
-		modules: {
-			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
-			teasers: {
-				teasers: _.map(['Custom Teaser 1', 'Custom Teaser 2', 'Custom Teaser 3'], function(value) {
-					return {
-						title: value,
-						text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.'
-					};
-				})
+		props: {
+			title: 'Page (custom teasers)',
+			text: 'This page demonstrates the inclusion of a module with custom data.',
+			modules: {
+				skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
+				teasers: {
+					teasers: _.map(['Custom Teaser 1', 'Custom Teaser 2', 'Custom Teaser 3'], function(value) {
+						return {
+							title: value,
+							text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.'
+						};
+					})
+				}
 			}
 		}
 	});

--- a/source/demo/pages/page_2/page_2.data.js
+++ b/source/demo/pages/page_2/page_2.data.js
@@ -10,7 +10,7 @@ var _ = require('lodash'),
 		title: 'Page (custom teasers)',
 		text: 'This page demonstrates the inclusion of a module with custom data.',
 		modules: {
-			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js'),
+			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
 			teasers: {
 				teasers: _.map(['Custom Teaser 1', 'Custom Teaser 2', 'Custom Teaser 3'], function(value) {
 					return {

--- a/source/demo/pages/page_2/page_2.hbs
+++ b/source/demo/pages/page_2/page_2.hbs
@@ -1,15 +1,19 @@
 {{#extend "layouts/layout"}}
 	{{#content "header"}}
-		{{> "demo/modules/skiplinks/skiplinks" modules.skiplinks}}
+		{{#with props}}
+			{{> "demo/modules/skiplinks/skiplinks" modules.skiplinks}}
+		{{/with}}
 	{{/content}}
 
 	{{#content "content"}}
-		<h2>{{title}}</h2>
+		{{#with props}}
+			<h2>{{title}}</h2>
 
-		<p>{{text}}</p>
+			<p>{{text}}</p>
 
-		<hr>
+			<hr>
 
-		{{> "demo/modules/teasers/teasers" modules.teasers}}
+			{{> "demo/modules/teasers/teasers" modules.teasers}}
+		{{/with}}
 	{{/content}}
 {{/extend}}

--- a/source/demo/pages/slideshow/slideshow.data.js
+++ b/source/demo/pages/slideshow/slideshow.data.js
@@ -11,11 +11,13 @@ var _ = require('lodash'),
 				dataHelper.getTestScriptPath('../../modules/slideshow/slideshow.test.js')
 			]
 		},
-		title: 'Unit test',
-		text: 'This page demonstrates the customized initialization of a module and allows to run its JavaScript unit tests.',
-		modules: {
-			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
-			slideshow: requireNew('../../modules/slideshow/slideshow.data.js').props
+		props: {
+			title: 'Unit test',
+			text: 'This page demonstrates the customized initialization of a module and allows to run its JavaScript unit tests.',
+			modules: {
+				skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
+				slideshow: requireNew('../../modules/slideshow/slideshow.data.js').props
+			}
 		}
 	});
 

--- a/source/demo/pages/slideshow/slideshow.data.js
+++ b/source/demo/pages/slideshow/slideshow.data.js
@@ -14,8 +14,8 @@ var _ = require('lodash'),
 		title: 'Unit test',
 		text: 'This page demonstrates the customized initialization of a module and allows to run its JavaScript unit tests.',
 		modules: {
-			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js'),
-			slideshow: requireNew('../../modules/slideshow/slideshow.data.js')
+			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props,
+			slideshow: requireNew('../../modules/slideshow/slideshow.data.js').props
 		}
 	});
 

--- a/source/demo/pages/slideshow/slideshow.hbs
+++ b/source/demo/pages/slideshow/slideshow.hbs
@@ -1,35 +1,39 @@
 {{#extend "layouts/layout"}}
 	{{#content "header"}}
-		<script>
-			// Global content data, will be extended by data-slideshow-data
-			estatico.helpers.extend(estatico.data, {
-				slideshow: {
-					i18n: {
-						prev: 'Previous',
-						next: 'Next'
+		{{#with props}}
+			<script>
+				// Global content data, will be extended by data-slideshow-data
+				estatico.helpers.extend(estatico.data, {
+					slideshow: {
+						i18n: {
+							prev: 'Previous',
+							next: 'Next'
+						}
 					}
-				}
-			});
+				});
 
-			// Global configuration data, will be extended by data-slideshow-options
-			estatico.helpers.extend(estatico.options, {
-				slideshow: {
-					animationDuration: 200,
-					url: '/mocks/demo/modules/slideshow/slideshow.json?delay=500'
-				}
-			});
-		</script>
+				// Global configuration data, will be extended by data-slideshow-options
+				estatico.helpers.extend(estatico.options, {
+					slideshow: {
+						animationDuration: 200,
+						url: '/mocks/demo/modules/slideshow/slideshow.json?delay=500'
+					}
+				});
+			</script>
 
-		{{> "demo/modules/skiplinks/skiplinks" modules.skiplinks}}
+			{{> "demo/modules/skiplinks/skiplinks" modules.skiplinks}}
+		{{/with}}
 	{{/content}}
 
 	{{#content "content"}}
-		<h2>{{title}}</h2>
+		{{#with props}}
+			<h2>{{title}}</h2>
 
-		<p>{{text}}</p>
+			<p>{{text}}</p>
 
-		<hr>
+			<hr>
 
-		{{> "demo/modules/slideshow/slideshow" modules.slideshow}}
+			{{> "demo/modules/slideshow/slideshow" modules.slideshow}}
+		{{/with}}
 	{{/content}}
 {{/extend}}

--- a/source/demo/pages/sublayout/sublayout.data.js
+++ b/source/demo/pages/sublayout/sublayout.data.js
@@ -11,7 +11,7 @@ var _ = require('lodash'),
 		text: 'This page demonstrates how to extend a sublayout.',
 		sidebar: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
 		modules: {
-			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js')
+			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props
 		}
 	});
 

--- a/source/demo/pages/sublayout/sublayout.data.js
+++ b/source/demo/pages/sublayout/sublayout.data.js
@@ -7,11 +7,13 @@ var _ = require('lodash'),
 		meta: {
 			title: 'Demo: 03 Sublayout'
 		},
-		title: 'Sublayout',
-		text: 'This page demonstrates how to extend a sublayout.',
-		sidebar: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-		modules: {
-			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props
+		props: {
+			title: 'Sublayout',
+			text: 'This page demonstrates how to extend a sublayout.',
+			sidebar: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+			modules: {
+				skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js').props
+			}
 		}
 	});
 

--- a/source/demo/pages/sublayout/sublayout.hbs
+++ b/source/demo/pages/sublayout/sublayout.hbs
@@ -1,17 +1,23 @@
 {{#extend "layouts/sublayout"}}
 	{{#content "header"}}
-		{{> "demo/modules/skiplinks/skiplinks" modules.skiplinks}}
+		{{#with props}}
+			{{> "demo/modules/skiplinks/skiplinks" modules.skiplinks}}
+		{{/with}}
 	{{/content}}
 
 	{{#content "main"}}
-		<h2>{{title}}</h2>
+		{{#with props}}
+			<h2>{{title}}</h2>
 
-		<p>{{text}}</p>
+			<p>{{text}}</p>
+		{{/with}}
 	{{/content}}
 
 	{{#content "sidebar"}}
-		<h2>Sidebar area</h2>
+		{{#with props}}
+			<h2>Sidebar area</h2>
 
-		<p>{{sidebar}}</p>
+			<p>{{sidebar}}</p>
+		{{/with}}
 	{{/content}}
 {{/extend}}

--- a/source/layouts/layout.hbs
+++ b/source/layouts/layout.hbs
@@ -6,7 +6,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>{{#if title}}{{title}} – {{/if}}{{project}}</title>
+	<title>{{#if title}}{{title}} – {{/if}}{{meta.project}}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<link rel="stylesheet" href="/assets/css/main{{#unless env.dev}}.min{{/unless}}.css">

--- a/source/layouts/layout.hbs
+++ b/source/layouts/layout.hbs
@@ -21,7 +21,7 @@
 		<script src="/assets/js/dev.js"></script>
 	{{/if}}
 </head>
-<body {{#if svgSprites}} data-svgsprites-options='{{svgSprites}}'{{/if}}>
+<body {{#if props.svgSprites}} data-svgsprites-options='{{props.svgSprites}}'{{/if}}>
 	{{#block "header"}}
 	{{/block}}
 

--- a/source/modules/.scaffold/scaffold.data.js
+++ b/source/modules/.scaffold/scaffold.data.js
@@ -6,23 +6,41 @@ var _ = require('lodash'),
 	handlebarsHelper = requireNew('../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../data/default.data.js'),
 
-	moduleData = {}, // Add data to be passed to the module template
 	template = dataHelper.getFileContent('{{name}}.hbs'),
-	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
-	data = _.merge(defaultData, moduleData, {
+	data = _.merge(defaultData, {
 		meta: {
 			title: '{{originalName}}',
 			className: '{{className}}',
 			keyName: '{{keyName}}',
 			jira: 'ESTATICO-*',
-			demo: compiledTemplate,
-			code: {
-				handlebars: dataHelper.getFormattedHandlebars(template),
-				html: dataHelper.getFormattedHtml(compiledTemplate),
-				data: dataHelper.getFormattedJson(moduleData)
-			},
 			documentation: dataHelper.getDocumentation('{{name}}.md')
+		},
+		props: {}
+	}),
+	variants = [
+		{
+			meta: {
+				title: 'Default',
+				desc: 'Default implementation'
+			}
 		}
+	].map(function(variant) {
+		var variantProps = _.merge({}, data, variant).props,
+			compiledVariant = handlebarsHelper.Handlebars.compile(template)(variantProps),
+			variantData = _.merge({}, data, variant, {
+				meta: {
+					demo: compiledVariant,
+					code: {
+						handlebars: dataHelper.getFormattedHandlebars(template),
+						html: dataHelper.getFormattedHtml(compiledVariant),
+						data: dataHelper.getFormattedJson(variantProps)
+					}
+				}
+			});
+
+		return variantData;
 	});
+
+data.variants = variants;
 
 module.exports = data;

--- a/source/modules/.scaffold/scaffold.data.js
+++ b/source/modules/.scaffold/scaffold.data.js
@@ -2,16 +2,28 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../helpers/data.js'),
+	dataHelper = requireNew('../../../helpers/data.js'),
+	handlebarsHelper = requireNew('../../../helpers/handlebars.js'),
 	defaultData = requireNew('../../data/default.data.js'),
+
+	moduleData = {}, // Add data to be passed to the module template
+	template = dataHelper.getFileContent('{{name}}.hbs'),
+	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
 	data = _.merge(defaultData, {
 		meta: {
 			title: '{{originalName}}',
 			className: '{{className}}',
 			keyName: '{{keyName}}',
-			code: dataHelper.getTemplateCode('{{name}}.hbs'),
+			jira: 'ESTATICO-*',
+			demo: compiledTemplate,
+			code: {
+				handlebars: dataHelper.getFormattedHandlebars(template),
+				html: dataHelper.getFormattedHtml(compiledTemplate),
+				data: dataHelper.getFormattedJson(moduleData)
+			},
 			documentation: dataHelper.getDocumentation('{{name}}.md')
-		}
+		},
+		module: moduleData
 	});
 
 module.exports = data;

--- a/source/modules/.scaffold/scaffold.data.js
+++ b/source/modules/.scaffold/scaffold.data.js
@@ -8,7 +8,7 @@ var _ = require('lodash'),
 
 	moduleData = {}, // Add data to be passed to the module template
 	template = dataHelper.getFileContent('{{name}}.hbs'),
-	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
+	compiledTemplate = handlebarsHelper.Handlebars.compile(template)(moduleData),
 	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: '{{originalName}}',

--- a/source/modules/.scaffold/scaffold.data.js
+++ b/source/modules/.scaffold/scaffold.data.js
@@ -9,7 +9,7 @@ var _ = require('lodash'),
 	moduleData = {}, // Add data to be passed to the module template
 	template = dataHelper.getFileContent('{{name}}.hbs'),
 	compiledTemplate = handlebarsHelper.compile(template)(moduleData),
-	data = _.merge(defaultData, {
+	data = _.merge(defaultData, moduleData, {
 		meta: {
 			title: '{{originalName}}',
 			className: '{{className}}',
@@ -22,8 +22,7 @@ var _ = require('lodash'),
 				data: dataHelper.getFormattedJson(moduleData)
 			},
 			documentation: dataHelper.getDocumentation('{{name}}.md')
-		},
-		module: moduleData
+		}
 	});
 
 module.exports = data;

--- a/source/pages/.scaffold/scaffold.data.js
+++ b/source/pages/.scaffold/scaffold.data.js
@@ -7,10 +7,13 @@ var _ = require('lodash'),
 		meta: {
 			title: '{{originalName}}'
 		},
-		title: '{{originalName}}',
-		text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-		modules: {
-			// xy: requireNew('../../modules/xy/xy.data.js')
+		props: {
+			title: '{{originalName}}',
+			text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+			modules: {
+
+				// xy: requireNew('../../modules/xy/xy.data.js').props
+			}
 		}
 	});
 

--- a/source/preview/layouts/layout.hbs
+++ b/source/preview/layouts/layout.hbs
@@ -6,7 +6,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>{{#if title}}{{title}} – {{/if}}{{project}}</title>
+	<title>{{#if title}}{{title}} – {{/if}}{{meta.project}}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<link rel="stylesheet" href="/assets/css/main{{#unless env.dev}}.min{{/unless}}.css">
@@ -17,7 +17,7 @@
 <body {{#if svgSprites}} data-svgsprites-options='{{svgSprites}}'{{/if}}>
 	<div class="sg_wrapper{{#if additionalLayoutClass}} {{additionalLayoutClass}}{{/if}}">
 		<h1 class="sg_title">
-			<a href="/" class="sg_logo">{{project}}</a>{{#if meta.title}} / {{meta.title}}{{/if}}
+			<a href="/" class="sg_logo">{{meta.project}}</a>{{#if meta.title}} / {{meta.title}}{{/if}}
 		</h1>
 
 		{{#block "content"}}

--- a/source/preview/layouts/layout.hbs
+++ b/source/preview/layouts/layout.hbs
@@ -14,7 +14,7 @@
 
 	<script src="/assets/js/head{{#unless env.dev}}.min{{/unless}}.js"></script>
 </head>
-<body {{#if svgSprites}} data-svgsprites-options='{{svgSprites}}'{{/if}}>
+<body {{#if props.svgSprites}} data-svgsprites-options='{{props.svgSprites}}'{{/if}}>
 	<div class="sg_wrapper{{#if additionalLayoutClass}} {{additionalLayoutClass}}{{/if}}">
 		<h1 class="sg_title">
 			<a href="/" class="sg_logo">{{meta.project}}</a>{{#if meta.title}} / {{meta.title}}{{/if}}

--- a/source/preview/layouts/module.hbs
+++ b/source/preview/layouts/module.hbs
@@ -6,7 +6,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>{{#if meta.title}}{{meta.title}} – {{/if}}{{project}}</title>
+	<title>{{#if meta.title}}{{meta.title}} – {{/if}}{{meta.project}}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<link rel="stylesheet" href="/assets/css/main{{#unless env.dev}}.min{{/unless}}.css">
@@ -25,10 +25,10 @@
 <body {{#if svgSprites}} data-svgsprites-options='{{svgSprites}}'{{/if}}>
 	<div class="sg_wrapper sg_module">
 		<h1 class="sg_title">
-			<a href="/" class="sg_logo">{{project}}</a>{{#if meta.title}} / {{meta.title}}{{/if}}
+			<a href="/" class="sg_logo">{{meta.project}}</a>{{#if meta.title}} / {{meta.title}}{{/if}}
 		</h1>
 
-		{{#if variants}}
+		{{#gt variants.length 1}}
 			<section class="sg_variants sg_inner_wrapper">
 				<h2 class="sg_h2">Module Preview</h2>
 
@@ -76,16 +76,19 @@
 		{{else}}
 			<section class="sg_inner_wrapper">
 				<h2 class="sg_h2">Module Preview</h2>
-				<div class="sg_demo">
-					{{#block "content"}}
-						{{{meta.demo}}}
-					{{/block}}
-				</div>
-			</section>
-		{{/if}}
+
+				{{#each variants}}
+					<div class="sg_demo">
+						{{#block "content"}}
+							{{{meta.demo}}}
+						{{/block}}
+					</div>
 
 {{! Indentation matters... }}
 {{> "preview/partials/code"}}
+				{{/each}}
+			</section>
+		{{/gt}}
 
 		{{#if meta.documentation}}
 			<section class="sg_inner_wrapper">

--- a/source/preview/layouts/module.hbs
+++ b/source/preview/layouts/module.hbs
@@ -22,7 +22,7 @@
 		<script src="/assets/js/dev.js"></script>
 	{{/if}}
 </head>
-<body {{#if svgSprites}} data-svgsprites-options='{{svgSprites}}'{{/if}}>
+<body {{#if props.svgSprites}} data-svgsprites-options='{{props.svgSprites}}'{{/if}}>
 	<div class="sg_wrapper sg_module">
 		<h1 class="sg_title">
 			<a href="/" class="sg_logo">{{meta.project}}</a>{{#if meta.title}} / {{meta.title}}{{/if}}

--- a/source/preview/layouts/module.hbs
+++ b/source/preview/layouts/module.hbs
@@ -41,7 +41,7 @@
 						{{#each variants}}
 							<div class="tab_content" id="panel{{@index}}" aria-labelledby="tabLabel{{@index}}" role="tabpanel">
 								<div class="sg_demo">
-									{{{demo}}}
+									{{{meta.demo}}}
 								</div>
 							</div>
 						{{/each}}
@@ -64,6 +64,9 @@
 										{{/if}}
 									</div>
 								{{/if}}
+{{! Indentation matters... }}
+{{> "preview/partials/code"}}
+
 							</div>
 						{{/each}}
 					</div>
@@ -75,16 +78,14 @@
 				<h2 class="sg_h2">Module Preview</h2>
 				<div class="sg_demo">
 					{{#block "content"}}
-						{{{demo}}}
+						{{{meta.demo}}}
 					{{/block}}
 				</div>
 			</section>
 		{{/if}}
 
-		<section class="sg_inner_wrapper">
-			<h2 class="sg_h2">Code</h2>
-			<pre class="sg_code hljs">{{{meta.code}}}</pre>
-		</section>
+{{! Indentation matters... }}
+{{> "preview/partials/code"}}
 
 		{{#if meta.documentation}}
 			<section class="sg_inner_wrapper">

--- a/source/preview/partials/code.hbs
+++ b/source/preview/partials/code.hbs
@@ -1,0 +1,20 @@
+{{#if meta.code}}
+	<section class="sg_inner_wrapper">
+		<h2 class="sg_h2">Code</h2>
+
+		{{#if meta.code.handlebars}}
+			<h3 class="sg_h3">Handlebars</h3>
+			<pre class="sg_code hljs">{{{meta.code.handlebars}}}</pre>
+		{{/if}}
+
+		{{#if meta.code.data}}
+			<h3 class="sg_h3">Data</h3>
+			<pre class="sg_code hljs">{{{meta.code.data}}}</pre>
+		{{/if}}
+
+		{{#if meta.code.html}}
+			<h3 class="sg_h3">Rendered HTML</h3>
+			<pre class="sg_code hljs">{{{meta.code.html}}}</pre>
+		{{/if}}
+	</section>
+{{/if}}


### PR DESCRIPTION
Goals:
- Show not only the handlebars template but also the data model and the resulting HTML. This is done for every variant. Currently, it is a "dumb" linear view, it would probably make sense to display this with tabs instead. However, since the module preview page needs some UX love anyway, I didn't tackle this here.
- Move logic from the `html` task to the data layer. The idea is to make it more obvious what's going on. While explicitly setting up variant data in the `.data.js` file instead of the gulp task might be a bit more "laborious", it should make it easier to debug and extend.
- Better structure data by splitting it into `meta` and `props` (for both modules and pages)

Visual result:
![image](https://cloud.githubusercontent.com/assets/654171/20965961/67cb7738-bc78-11e6-8ac7-56fda3f0842e.png)

What do you think?