### PR TITLE
Replace _.pluck() in favour of _.map()

### DIFF
--- a/gulp/scaffold/delete.js
+++ b/gulp/scaffold/delete.js
@@ -50,8 +50,8 @@ var taskName = 'scaffold:delete',
 			})
 			.then(function(response) {
 				if (_.isArray(response)) {
-					scaffoldConfig.name = _.pluck(response, 'name');
-					scaffoldConfig.src = _.pluck(response, 'src');
+					scaffoldConfig.name = _.map(response, 'name');
+					scaffoldConfig.src = _.map(response, 'src');
 				} else {
 					scaffoldConfig.name = response.name;
 					scaffoldConfig.className = response.className;


### PR DESCRIPTION
According to Loash changlog, the use of _.pluck has been removed in favor of _.map with iteratee shorthand:

```js
var objects = [{ 'a': 1 }, { 'a': 2 }];

// in 3.10.1
_.pluck(objects, 'a'); // ➜ [1, 2]
_.map(objects, 'a'); // ➜ [1, 2]

// in 4.0.0
_.map(objects, 'a'); // ➜ [1, 2]
```

https://github.com/lodash/lodash/wiki/Changelog#v400