### PR TITLE
fixed and improved JS scaffolding

### DIFF
--- a/gulp/scaffold/default.js
+++ b/gulp/scaffold/default.js
@@ -48,7 +48,7 @@ var taskName = 'scaffold',
 			src: './source/assets/js/helpers/estaticoapp.js',
 			insertionPoint: '/* autoinsertmodule */',
 			importInsertionPoint: '/* autoinsertmodulereference */',
-			insertionTemplate: 'this.modules.{{keyName}} = {{className}};\n		',
+			insertionTemplate: 'this.modules[{{className}}.name] = {{className}};\n		',
 			importInsertionTemplate: 'import {{className}} from \'{{modulePath}}\';\n'
 		},
 

--- a/source/assets/js/helpers/module.js
+++ b/source/assets/js/helpers/module.js
@@ -12,7 +12,7 @@ class EstaticoModule {
 	* @param  {object} options - The options passed as data attribute in the Module
 	*/
 	constructor($element, _defaultData, _defaultOptions, data, options) {
-		this.name = this.constructor.name.toLowerCase();
+		this.name = this.constructor.name;
 
 		this.ui = {
 			$element

--- a/source/modules/.scaffold/scaffold.hbs
+++ b/source/modules/.scaffold/scaffold.hbs
@@ -1,3 +1,3 @@
-<div class="mod_{{name}}" data-init="{{name}}">
+<div class="mod_{{name}}" data-init="{{className}}">
 	{{originalName}}
 </div>

--- a/source/modules/.scaffold/scaffold.hbs
+++ b/source/modules/.scaffold/scaffold.hbs
@@ -1,3 +1,3 @@
-<div class="mod_{{name}}" data-init="{{className}}">
+<div class="mod_{{name}}" data-init="{{name}}">
 	{{originalName}}
 </div>

--- a/source/modules/.scaffold/scaffold.js
+++ b/source/modules/.scaffold/scaffold.js
@@ -1,39 +1,49 @@
-/*!
+import EstaticoModule from '../../assets/js/helpers/module';
+
+const name = '{{name}}';
+
+/*
  * {{originalName}}
  *
  * @author
  * @copyright
  */
-import EstaticoModule from '../../assets/js/helpers/module';
-
-class {{className}} extends EstaticoModule {
+export default class {{className}} extends EstaticoModule {
+	static events = {
+		// eventname: `eventname.estatico.${name}`
+	};
+	static defaultData = {};
+	static defaultOptions = {
+		domSelectors: {
+			// item: `[data-${name}="item"]`
+		},
+		stateClasses: {
+			// activated: 'is_activated'
+		}
+	};
 
 	constructor($element, data, options) {
-		let _defaultData = {},
-			_name = '{{name}}',
-			_defaultOptions = {
-				domSelectors: {
-					// item: '[data-' + _name + '="item"]'
-				},
-				stateClasses: {
-					// activated: 'is_activated'
-				}
-			};
-
-		super($element, _defaultData, _defaultOptions, data, options);
+		super($element, {{className}}.defaultData, {{className}}.defaultOptions, data, options);
 
 		this._initUi();
 		this._initEventListeners();
 	}
 
-	static get events() {
-		return {
-			// eventname: 'eventname.estatico.' + {{name}}
-		};
+	/**
+	 * Unbind events, remove data, custom teardown
+	 *
+	 * @public
+	 */
+	destroy() {
+		super.destroy();
+
+		// Custom destroy actions go here
 	}
 
 	/**
 	 * Initialisation of variables, which point to DOM elements
+	 *
+	 * @private
 	 */
 	_initUi() {
 		// DOM element pointers
@@ -41,19 +51,10 @@ class {{className}} extends EstaticoModule {
 
 	/**
 	 * Event listeners initialisation
+	 *
+	 * @private
 	 */
 	_initEventListeners() {
 		// Event listeners
 	}
-
-	/**
-	 * Unbind events, remove data, custom teardown
-	 */
-	destroy() {
-		super.destroy();
-
-		// Custom destroy actions go here
-	}
 }
-
-export default {{className}};

--- a/source/modules/.scaffold/scaffold.js
+++ b/source/modules/.scaffold/scaffold.js
@@ -1,7 +1,5 @@
 import EstaticoModule from '../../assets/js/helpers/module';
 
-const name = '{{name}}';
-
 /*
  * {{originalName}}
  *
@@ -10,12 +8,12 @@ const name = '{{name}}';
  */
 export default class {{className}} extends EstaticoModule {
 	static events = {
-		// eventname: `eventname.estatico.${name}`
+		// eventname: `eventname.estatico.${{{className}}.name}`
 	};
 	static defaultData = {};
 	static defaultOptions = {
 		domSelectors: {
-			// item: `[data-${name}="item"]`
+			// item: `[data-${{{className}}.name}}="item"]`
 		},
 		stateClasses: {
 			// activated: 'is_activated'


### PR DESCRIPTION
**Fixes the initialization of the JS for modules**

Refactoring:
- the name, events and default options are defined as constants or at least static (again), in the latest version the variables were recreated for every instance/every call of ClassName.events
- the import statement was moved to the top of the file (more common)
- The class comment is not longer preserved
- the extra line for "export default" was removed and replaced with "export default class"
- ES6 string substitution used
- some JSdoc was added (accessors)
- the destroy method was moved up