### PR TITLE
Refactors variants with additional key

### DIFF
--- a/source/demo/modules/teaser/teaser.data.js
+++ b/source/demo/modules/teaser/teaser.data.js
@@ -15,15 +15,17 @@ var data = _.merge(defaultData, {
 		variants: [
 			{
 				meta: {
-					title: 'No text',
-					desc: 'Used when there are no words.'
+					title: 'Teaser no text',
+					desc: 'Used when there are no words.',
+					key: 'no text'
 				},
 				title: 'Teaser title'
 			},
 			{
 				meta: {
-					title: 'Inverted',
-					desc: 'Used at night. Set `variant` to `var_inverted`.'
+					title: 'Teaser Inverted',
+					desc: 'Used at night. Set `variant` to `var_inverted`.',
+					key: 'inverted'
 				},
 				title: 'Teaser title',
 				text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',

--- a/source/demo/modules/teasers/teasers.data.js
+++ b/source/demo/modules/teasers/teasers.data.js
@@ -17,7 +17,21 @@ var data = _.merge(defaultData, {
 			return _.merge({}, teaserData, {
 				title: value
 			});
-		})
+		}),
+
+		variants: [
+			{
+				meta: {
+					title: 'Teasers inverted',
+					key: 'inverted'
+				},
+				teasers: _.map(['Teaser 1', 'Teaser 2', 'Teaser 3', 'Teaser 4'], function(value) {
+					return _.merge({}, teaserData.variants.find((variants) => variants.meta.key === 'inverted'), {
+						title: value
+					});
+				})
+			}
+		]
 	});
 
 module.exports = data;

--- a/source/demo/pages/page/page.data.js
+++ b/source/demo/pages/page/page.data.js
@@ -2,7 +2,8 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	defaultData = requireNew('../../../data/default.data.js');
+	defaultData = requireNew('../../../data/default.data.js'),
+	teasersData = requireNew('../../modules/teasers/teasers.data.js');
 
 var data = _.merge(defaultData, {
 		meta: {
@@ -12,7 +13,8 @@ var data = _.merge(defaultData, {
 		text: 'This page demonstrates the inclusion of a module.',
 		modules: {
 			skiplinks: requireNew('../../modules/skiplinks/skiplinks.data.js'),
-			teasers: requireNew('../../modules/teasers/teasers.data.js')
+			teasers: teasersData,
+			teasersInverted: teasersData.variants.find((variants) => variants.meta.key === 'inverted')
 		}
 	});
 

--- a/source/demo/pages/page/page.hbs
+++ b/source/demo/pages/page/page.hbs
@@ -11,5 +11,7 @@
 		<hr>
 
 		{{> "demo/modules/teasers/teasers" modules.teasers}}
+		{{> "demo/modules/teasers/teasers" modules.teasersInverted}}
+
 	{{/content}}
 {{/extend}}


### PR DESCRIPTION
Includes a specific variant with the key property by adding a key property in meta data.
```
exampleData.variants.find((variants) => variants.meta.key === 'inverted')
```

this allows you to change the order of variants without changing the variants include in data.js file.
See also original pr: https://github.com/unic/estatico/pull/29