### PR TITLE
[Update] Log helper: Set new default logger this.log

### DIFF
--- a/source/assets/js/helpers/module.js
+++ b/source/assets/js/helpers/module.js
@@ -27,7 +27,10 @@ class EstaticoModule {
 		// Identify instance by UUID
 		this.uuid = _.uniqueId(this.name);
 
-		this.log = window.estatico.helpers.log;
+		this.log = window.estatico.helpers.log(this.name);
+
+		// Expose original log helper
+		this._log = window.estatico.helpers.log;
 	}
 
 	static get initEvents() {


### PR DESCRIPTION
Make `this.log` default logger as discussed in:
https://github.com/unic/estatico/issues/18

