### PR TITLE
made further improvements to the dependency graph pattern

### DIFF
--- a/gulp/html/default.js
+++ b/gulp/html/default.js
@@ -90,7 +90,7 @@ var taskName = 'html',
 
 				// Create dependency graph of currently piped file
 				var dependencyGraph = new helpers.dependencygraph(file.path, {
-						pattern: /{{>[\s-]*"?(.*?)["|\s](.*?)}}/g,
+						pattern: /{{>[\s-]*"?([^"\s(]+)["|\s][\s]?(.*?)}}/g,
 						resolvePath: function(match) {
 							var resolvedPath = path.resolve('./source/', match + '.hbs');
 


### PR DESCRIPTION
Made further improvements to the dependency graph pattern so it does not conflict with includes like `{{>(lookup 'partial') modules.slideshow}}`

Background:
Instead `{{dynamicPartial partial modules.slideshow}}` we often use `{{> (lookup 'partial') modules.slideshow}}` where possible, because it does not require a custom handlebars helper. (`dynamicPartial` is still helpful for more complex cases)