### PR TITLE
linked the used sub modules in the template code 

### DIFF
--- a/helpers/data.js
+++ b/helpers/data.js
@@ -74,14 +74,11 @@ module.exports = {
 		var stack = callsite(),
 			requester = stack[1].getFileName(),
 			requirePath = path.resolve(path.dirname(requester), filePath),
-			content = getFile(requirePath);
-
-		var highlighted = Highlight.highlight('html', content).value;
+			content = getFile(requirePath),
+			highlighted = Highlight.highlight('html', content).value;
 
 		// Link the used sub modules (excludes partials starting with underscore)
-		highlighted = highlighted.replace(/({{&gt;[\s"]*)(([\/]?[!a-z][a-z0-9-_]+)+)([\s"}]+)/g, '$1<a href="/$2.html">$2</a>$4');
-
-		return highlighted;
+		return highlighted.replace(/({{&gt;[\s"]*)(([\/]?[!a-z][a-z0-9-_]+)+)([\s"}]+)/g, '$1<a href="/$2.html">$2</a>$4');
 	},
 
 	getDataMock: function(filePath) {

--- a/helpers/data.js
+++ b/helpers/data.js
@@ -76,7 +76,12 @@ module.exports = {
 			requirePath = path.resolve(path.dirname(requester), filePath),
 			content = getFile(requirePath);
 
-		return Highlight.highlight('html', content).value;
+		var highlighted = Highlight.highlight('html', content).value;
+
+		// Link the used sub modules (excludes partials starting with underscore)
+		highlighted = highlighted.replace(/({{&gt;[\s"]*)(([\/]?[!a-z][a-z0-9-_]+)+)([\s"}]+)/g, '$1<a href="/$2.html">$2</a>$4');
+
+		return highlighted;
 	},
 
 	getDataMock: function(filePath) {


### PR DESCRIPTION
This adds links to the template code in the module preview pages, like here:
![bildschirmfoto 2017-03-09 um 11 21 39](https://cloud.githubusercontent.com/assets/568574/23745988/a103bfa8-04ba-11e7-8877-8591f5b6d9d8.png)

The Regex is working for several styles and combinations, see https://regex101.com/r/4LdAMn/2