### PR TITLE
[Feature] Moving code and documentation data to build

### DIFF
--- a/gulp/html/default.js
+++ b/gulp/html/default.js
@@ -128,6 +128,8 @@ var taskName = 'html',
 			}))
 			.pipe(tap(function(file) {
 				var dataFile = util.replaceExtension(file.path, '.data.js'),
+					documentationFile = util.replaceExtension(file.path, '.md'),
+					templateFile = util.replaceExtension(file.path, '.hbs'),
 					data = (function() {
 						try {
 							return requireNew(dataFile);
@@ -170,6 +172,14 @@ var taskName = 'html',
 							}
 						);
 						data.variants.unshift(mergedData);
+					}
+
+					// Fill the template code data to be passed into module meta data
+					data.meta.code = helpers.data.getTemplateCode(templateFile);
+
+					// If .md file exists, fill the documentation data to be passed into module meta data
+					if (fs.existsSync(documentationFile)) {
+						data.meta.documentation = helpers.data.getDocumentation(documentationFile);
 					}
 
 					// Replace file content with preview template

--- a/source/demo/modules/imageversions/imageversions.data.js
+++ b/source/demo/modules/imageversions/imageversions.data.js
@@ -2,13 +2,10 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 	data = _.merge(defaultData, {
 		meta: {
-			title: 'Demo: Image versions',
-			code: dataHelper.getTemplateCode('imageversions.hbs'),
-			documentation: dataHelper.getDocumentation('imageversions.md')
+			title: 'Demo: Image versions'
 		}
 	});
 

--- a/source/demo/modules/media/media.data.js
+++ b/source/demo/modules/media/media.data.js
@@ -2,13 +2,11 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Media demo',
-			jira: 'JIRA-3',
-			code: dataHelper.getTemplateCode('media.hbs')
+			jira: 'JIRA-3'
 		}
 	});
 

--- a/source/demo/modules/skiplinks/skiplinks.data.js
+++ b/source/demo/modules/skiplinks/skiplinks.data.js
@@ -2,13 +2,11 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Skiplinks',
-			jira: 'JIRA-5',
-			code: dataHelper.getTemplateCode('skiplinks.hbs')
+			jira: 'JIRA-5'
 		},
 		links: [
 			{

--- a/source/demo/modules/slideshow/slideshow.data.js
+++ b/source/demo/modules/slideshow/slideshow.data.js
@@ -9,8 +9,6 @@ var _ = require('lodash'),
 			title: 'Demo: Slideshow',
 			className: 'SlideShow',
 			jira: 'JIRA-4',
-			code: dataHelper.getTemplateCode('slideshow.hbs'),
-			documentation: dataHelper.getDocumentation('slideshow.md'),
 			testScripts: [
 				dataHelper.getTestScriptPath('slideshow.test.js')
 			],

--- a/source/demo/modules/svgsprite/svgsprite.data.js
+++ b/source/demo/modules/svgsprite/svgsprite.data.js
@@ -5,7 +5,6 @@ var _ = require('lodash'),
 	glob = require('glob'),
 	path = require('path'),
 	spriteTask = require('../../../../gulp/media/svgsprite.js'),
-	dataHelper = require('../../../../helpers/data.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 	sprites = _.mapValues(spriteTask.taskConfig.src, function(globs) {
 		var files = [];
@@ -27,9 +26,7 @@ var _ = require('lodash'),
 	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: SVG icons',
-			jira: 'ESTATICO-212',
-			code: dataHelper.getTemplateCode('svgsprite.hbs'),
-			documentation: dataHelper.getDocumentation('svgsprite.md')
+			jira: 'ESTATICO-212'
 		},
 		svgSprites: JSON.stringify(JSON.parse(defaultData.svgSprites || '[]').concat([
 			'/assets/media/svg/demo.svg'

--- a/source/demo/modules/teaser/teaser.data.js
+++ b/source/demo/modules/teaser/teaser.data.js
@@ -2,12 +2,10 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 	data = _.merge(defaultData, {
 		meta: {
-			title: 'Demo: Teaser with module variants',
-			code: dataHelper.getTemplateCode('teaser.hbs')
+			title: 'Demo: Teaser with module variants'
 		},
 		title: 'Teaser title',
 		text: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',

--- a/source/demo/modules/teasers/teasers.data.js
+++ b/source/demo/modules/teasers/teasers.data.js
@@ -2,15 +2,13 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../../helpers/data.js'),
 	defaultData = requireNew('../../../data/default.data.js'),
 	teaserData = requireNew('../teaser/teaser.data.js'),
 	data = _.merge(defaultData, {
 		meta: {
 			title: 'Demo: Teasers',
 			jira: 'JIRA-1',
-			feature: 'Feature X',
-			code: dataHelper.getTemplateCode('teasers.hbs')
+			feature: 'Feature X'
 		},
 		teasers: _.map(['Teaser 1', 'Teaser 2', 'Teaser 3', 'Teaser 4'], function(value) {
 			return _.merge({}, teaserData, {

--- a/source/modules/.scaffold/scaffold.data.js
+++ b/source/modules/.scaffold/scaffold.data.js
@@ -2,15 +2,12 @@
 
 var _ = require('lodash'),
 	requireNew = require('require-new'),
-	dataHelper = require('../../../helpers/data.js'),
 	defaultData = requireNew('../../data/default.data.js'),
 	data = _.merge(defaultData, {
 		meta: {
 			title: '{{originalName}}',
 			className: '{{className}}',
-			keyName: '{{keyName}}',
-			code: dataHelper.getTemplateCode('{{name}}.hbs'),
-			documentation: dataHelper.getDocumentation('{{name}}.md')
+			keyName: '{{keyName}}'
 		}
 	});
 


### PR DESCRIPTION
Moving data needed only for module preview into build process. This should lessen performance impact on requiring .data.js files within each other.

