### PR TITLE
moved babel-polyfill from head.js to main.js

### DIFF
--- a/source/assets/js/head.js
+++ b/source/assets/js/head.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import '../.tmp/modernizr';
 import FontLoader from './helpers/fontloader';
 import Helper from './helpers/helper';

--- a/source/assets/js/main.js
+++ b/source/assets/js/main.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import datasetPolyfill from 'element-dataset';
 import 'handlebars/dist/handlebars';
 import './helpers/module';


### PR DESCRIPTION
moved babel-polyfill from `head.js` to `main.js` (to reduce `head.js`' file size)

At the moment there is no need for the polyfills in the head. If there is one in future, it will be better to pick the specific objects/functions from `core-js`.

(In future it also could be helpful to have a custom polyfill build (with selected `core-js` objects/functions) in `main.js` instead of including the whole package.)