### PR TITLE
create html:copy task

### DIFF
--- a/docs/Tasks.md
+++ b/docs/Tasks.md
@@ -57,8 +57,8 @@ Encode *.otf or *.ttf or *.woff fonts to base64 data
 Compile Handlebars templates to HTML. Use `.data.js` files for - surprise! - data.
 By default, a very basic dependency graph makes sure that only the necessary files are rebuilt on changes. Add the `--skipHtmlDependencyGraph` flag to disable this behavior and just build everything all the time.
 
-### `gulp html:copy`
-Copy the handlebars files to the assets folder.
+### `gulp html:hbs:copy`
+Copy the handlebars files to the assets folder. Note: this task is disabled by default. You need to enable this in build.js
 
 ### `gulp html:migrate`
 Transform old `.json` data files to `.data.js`.

--- a/docs/Tasks.md
+++ b/docs/Tasks.md
@@ -57,6 +57,9 @@ Encode *.otf or *.ttf or *.woff fonts to base64 data
 Compile Handlebars templates to HTML. Use `.data.js` files for - surprise! - data.
 By default, a very basic dependency graph makes sure that only the necessary files are rebuilt on changes. Add the `--skipHtmlDependencyGraph` flag to disable this behavior and just build everything all the time.
 
+### `gulp html:copy`
+Copy the handlebars files to the assets folder.
+
 ### `gulp html:migrate`
 Transform old `.json` data files to `.data.js`.
 

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -36,6 +36,7 @@ gulp.task(taskName, function(cb) {
 					'js:modernizr',
 					[
 						'html',
+						'html:copy',
 						'js',
 						'css',
 						'media:copy',

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -36,8 +36,8 @@ gulp.task(taskName, function(cb) {
 					'js:modernizr',
 					[
 						'html',
-						// The html:copy task is disabled by default. Uncomment it if you need it in your project.
-						//'html:copy',
+						// The html:hbs:copy task is disabled by default. Uncomment it if you need it in your project.
+						// 'html:hbs:copy',
 						'js',
 						'css',
 						'media:copy',

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -36,7 +36,8 @@ gulp.task(taskName, function(cb) {
 					'js:modernizr',
 					[
 						'html',
-						'html:copy',
+						// The html:copy task is disabled by default. Uncomment it if you need it in your project.
+						//'html:copy',
 						'js',
 						'css',
 						'media:copy',

--- a/gulp/html/copy.js
+++ b/gulp/html/copy.js
@@ -1,5 +1,10 @@
 'use strict';
 
+/**
+ * @function `gulp html:copy`
+ * @desc Copy the handlebars files to the assets folder.
+ */
+
 var gulp = require('gulp'),
     htmlTask = require('./default');
 

--- a/gulp/html/copy.js
+++ b/gulp/html/copy.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var gulp = require('gulp'),
+    htmlTask = require('./default');
+
+var taskName = 'html:copy',
+	taskConfig = {
+		src: htmlTask.taskConfig.src,
+		dest: './build/assets/html',
+		watch: htmlTask.taskConfig.src
+	},
+	task = function(config) {
+		return gulp.src(config.src, {
+				base: './source'
+			})
+			.pipe(gulp.dest(config.dest));
+	};
+
+gulp.task(taskName, function() {
+	return task(taskConfig);
+});
+
+module.exports = {
+	taskName: taskName,
+	taskConfig: taskConfig,
+	task: task
+};

--- a/gulp/html/copy.js
+++ b/gulp/html/copy.js
@@ -3,11 +3,12 @@
 var gulp = require('gulp'),
     htmlTask = require('./default');
 
-var taskName = 'html:copy',
+var src = ['source/**/*.hbs'],
+	taskName = 'html:copy',
 	taskConfig = {
-		src: htmlTask.taskConfig.src,
+		src: src,
 		dest: './build/assets/html',
-		watch: htmlTask.taskConfig.src
+		watch: src
 	},
 	task = function(config) {
 		return gulp.src(config.src, {

--- a/gulp/html/hbs-copy.js
+++ b/gulp/html/hbs-copy.js
@@ -1,18 +1,18 @@
 'use strict';
 
 /**
- * @function `gulp html:copy`
- * @desc Copy the handlebars files to the assets folder.
+ * @function `gulp html:hbs:copy`
+ * @desc Copy the handlebars files to the assets folder. Note: this task is disabled by default. You need to enable this in build.js	
  */
 
 var gulp = require('gulp'),
     htmlTask = require('./default');
 
 var src = ['source/**/*.hbs'],
-	taskName = 'html:copy',
+	taskName = 'html:hbs:copy',
 	taskConfig = {
 		src: src,
-		dest: './build/assets/html',
+		dest: './build/templates/',
 		watch: src
 	},
 	task = function(config) {


### PR DESCRIPTION
Created a html:copy task to have the handlebars templates as part of the assets.
This task is handy when the backend developers directly call the handlebars templates to render the HTML.

Thoughts?