### PR TITLE
add publish task

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -18,7 +18,8 @@ gulp.task(taskName, function(cb) {
 		runSequence = require('run-sequence'),
 		util = require('gulp-util'),
 		_ = require('lodash'),
-		inquirer = require('inquirer');
+		inquirer = require('inquirer'),
+		publishTask = require('./publish');
 
 	var callback = function(skipTests, cb) {
 			// Currently, the modernizr task cannot run in parallel with other tasks. This should get fixed as soon as Modernizr 3 is published and the plugin is officially released.
@@ -41,20 +42,24 @@ gulp.task(taskName, function(cb) {
 						'media:copy',
 						'media:imageversions'
 					],
-					'js:qunit',
-					function(err) {
-						if (err) {
-							helpers.errors(err);
-						}
-
-						cb();
-					}
+					'js:qunit'
 				];
 
 			if (skipTests) {
 				runTasks = _.without(runTasks, 'js:qunit');
 			}
 
+			if(publishTask.taskConfig.isEnabled) {
+				runTasks.push('publish');
+			}
+
+			runTasks.push(function(err) {
+				if (err) {
+					helpers.errors(err);
+				}
+
+				cb();
+			});
 			runSequence.apply(this, runTasks);
 		};
 

--- a/gulp/publish.js
+++ b/gulp/publish.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const gulp = require('gulp'),
+      util = require('gulp-util');
+
+const dest = util.env.publishDest,
+      taskName = 'publish',
+      taskConfig = {
+          src: './build/assets/**',
+          watch: './build/assets/**',
+          dest: dest,
+          isEnabled: !!dest,
+          returnChangedFileOnWatch: true
+      },
+      task = function(config, cb, changedFile) {
+        gulp.src(changedFile ? changedFile : config.src, {
+                base: './build/assets'
+            })
+            .pipe(gulp.dest(config.dest))
+            .on('end', cb);
+	};
+
+gulp.task(taskName, function(cb) {
+	return task(taskConfig, cb);
+});;
+
+
+module.exports = {
+	taskName: taskName,
+	taskConfig: taskConfig,
+	task: task
+};

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -25,7 +25,7 @@ gulp.task(taskName, function() {
 	var initWatchTasks = function(tasks) {
 			_.each(tasks, function(config) {
 				if (config.taskName) {
-					if (config.taskConfig.watch) {
+					if (config.taskConfig.watch && config.taskConfig.isEnabled !== false) {
 						var watcher = watch(config.taskConfig.watch, {
 								usePolling: !!(util.env.pollWatch && util.env.pollWatch !== 'false')
 							}, function(file) {


### PR DESCRIPTION
added a new task to allow publishing the assets directly to a location outside the frontend repo.
Again this is useful for backend developers which want to publish the assets directly to their "web-root" (or whatever it is called in the respective technology).
The publish task do nothing, except you set the `--publishDest` parameter on the command line.

@backflip  What do you thing about this one - is this something which should go into estatico, or is this too project-sepecific?