### PR TITLE
Fixes #85: Add size watermark to generated images

### DIFF
--- a/gulp/media/imageversions.js
+++ b/gulp/media/imageversions.js
@@ -24,7 +24,8 @@ var taskName = 'media:imageversions',
 		fileExtensionPattern: '*.{jpg, png}',
 		configFileName: 'imageversions.config.js',
 		srcBase: './source/',
-		dest: './build/'
+		dest: './build/',
+		addSizeWatermark: true
 	},
 	task = function(config, cb) {
 		var helpers = require('require-dir')('../../helpers'),
@@ -65,6 +66,11 @@ var taskName = 'media:imageversions',
 
 				// resize crop result to requested size
 				imgData.img.resize(newSize.width, newSize.height, '!');
+
+				// draw size on image to allow for easier testing of responsive images
+				if (config.addSizeWatermark) {
+					imgData.img.fontSize(16).box('#fff').fill('#000').drawText(20, 16, newSize.width + 'x' + newSize.height, 'southeast');
+				}
 
 				return imgData.img;
 			},


### PR DESCRIPTION
Writes the generated image's size onto the bottom right corner:
![image](https://user-images.githubusercontent.com/654171/32015424-5d10aff6-b9c1-11e7-9993-cfd4d5b58359.png)

PSA: Locally, I had to reinstall GraphicsMagick to make this work. And possibly `ghostscript`, not sure what fixed my issue with the text not appearing on the image. Teamcity worked fine without any changes. And Netlify was happy, too: https://deploy-preview-87--estatico.netlify.com/demo/modules/imageversions/imageversions.html